### PR TITLE
fix: grid elements flash as wrong size

### DIFF
--- a/src/components/uikit/layout/Grid.tsx
+++ b/src/components/uikit/layout/Grid.tsx
@@ -35,7 +35,7 @@ export function Grid({
       style={[rest.style, { margin: theme.space[spacing] / -2 }]}
       onLayout={(e: LayoutChangeEvent) => setWidth(e.nativeEvent.layout.width)}
     >
-      {colWidth !== undefined && 
+      {colWidth !== undefined &&
         elements.map((child, index) => {
           return (
             <View

--- a/src/components/uikit/layout/Grid.tsx
+++ b/src/components/uikit/layout/Grid.tsx
@@ -35,19 +35,20 @@ export function Grid({
       style={[rest.style, { margin: theme.space[spacing] / -2 }]}
       onLayout={(e: LayoutChangeEvent) => setWidth(e.nativeEvent.layout.width)}
     >
-      {elements.map((child, index) => {
-        return (
-          <View
-            key={index}
-            style={{
-              margin: theme.space[spacing] / 2,
-              width: colWidth && colWidth - theme.space[spacing],
-            }}
-          >
-            {isValidElement(child) ? cloneElement(child) : null}
-          </View>
-        );
-      })}
+      {colWidth !== undefined && 
+        elements.map((child, index) => {
+          return (
+            <View
+              key={index}
+              style={{
+                margin: theme.space[spacing] / 2,
+                width: colWidth && colWidth - theme.space[spacing],
+              }}
+            >
+              {isValidElement(child) ? cloneElement(child) : null}
+            </View>
+          );
+        })}
     </Wrapper>
   );
 }


### PR DESCRIPTION
Because the element size is handled in onLayout -method, the width can be -1 for a one frame or so. This can make the grid items be the "original" size for a moment and then scale to the correct width.

I suggest that we could hide the elements while the colWidth === undefined, so that we show nothing until the width of the parent is calculated