### PR TITLE
chore: import orders fixed

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,21 +6,21 @@
     "plugin:react-hooks/recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:lodash/recommended",
-    "plugin:prettier/recommended"
+    "plugin:prettier/recommended",
   ],
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint", "import", "lodash", "prettier"],
   "parserOptions": {
     "sourceType": "module",
-    "ecmaVersion": 2020
+    "ecmaVersion": 2020,
   },
   "env": {
-    "es6": true
+    "es6": true,
   },
   "settings": {
     "react": {
-      "version": "detect"
-    }
+      "version": "detect",
+    },
   },
   "globals": {
     "__DEV__": true,
@@ -65,7 +65,7 @@
     "URLSearchParams": false,
     "WebSocket": true,
     "window": false,
-    "XMLHttpRequest": false
+    "XMLHttpRequest": false,
   },
   "rules": {
     // You must disable the base rule as it can report incorrect errors
@@ -83,7 +83,7 @@
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-unused-vars": [
       "error",
-      { "argsIgnorePattern": "^_" }
+      { "argsIgnorePattern": "^_" },
     ],
     "@typescript-eslint/explicit-module-boundary-types": "off",
 
@@ -106,11 +106,20 @@
     "import/order": [
       "error",
       {
+        "pathGroups": [
+          {
+            "pattern": "{~*,~*/**}",
+            "group": "internal",
+            "position": "after",
+          },
+        ],
         "groups": [
           ["builtin", "external", "internal"],
-          ["parent", "sibling", "index"]
-        ]
-      }
-    ]
-  }
+          ["parent", "sibling", "index"],
+        ],
+        "newlines-between": "always",
+        "alphabetize": { "order": "asc", "caseInsensitive": false },
+      },
+    ],
+  },
 }

--- a/src/Providers.tsx
+++ b/src/Providers.tsx
@@ -1,11 +1,11 @@
 import type { ReactNode } from 'react';
 
-import { styled } from '~styles';
-import { ColorModeProvider } from '~services/color-mode';
-import { I18nProvider } from '~services/i18n';
-import Toaster from '~components/common/Toaster';
 import ErrorBoundary from '~components/common/ErrorBoundary';
 import NavigationThemeProvider from '~components/common/NavigationThemeProvider';
+import Toaster from '~components/common/Toaster';
+import { ColorModeProvider } from '~services/color-mode';
+import { I18nProvider } from '~services/i18n';
+import { styled } from '~styles';
 
 export default function Providers({ children }: { children: ReactNode }) {
   return (

--- a/src/app/(auth)/_layout.tsx
+++ b/src/app/(auth)/_layout.tsx
@@ -1,5 +1,6 @@
 import { t } from '@lingui/macro';
 import { Stack } from 'expo-router';
+
 import { useDefaultStackScreenOptions } from '~utils/navigation';
 
 export default function AuthLayout() {

--- a/src/app/(auth)/landing.tsx
+++ b/src/app/(auth)/landing.tsx
@@ -1,13 +1,13 @@
 import { t, Trans } from '@lingui/macro';
+import { Link } from 'expo-router';
 import { useWindowDimensions } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as DropdownMenu from 'zeego/dropdown-menu';
-import { Link } from 'expo-router';
 
-import { styled, useTheme } from '~styles';
+import StatusBar from '~components/common/StatusBar';
 import { IconButton, Stack, Text } from '~components/uikit';
 import { useI18n } from '~services/i18n';
-import StatusBar from '~components/common/StatusBar';
+import { styled, useTheme } from '~styles';
 
 export default function Landing() {
   const { height } = useWindowDimensions();

--- a/src/app/(auth)/login.tsx
+++ b/src/app/(auth)/login.tsx
@@ -1,11 +1,11 @@
-import { useForm, Controller } from 'react-hook-form';
 import { t, Trans } from '@lingui/macro';
+import { Controller, useForm } from 'react-hook-form';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 
-import { styled } from '~styles/styled';
 import { showToast } from '~components/common/Toaster';
-import { FillButton, Text, TextInput, Stack } from '~components/uikit';
+import { FillButton, Stack, Text, TextInput } from '~components/uikit';
 import { useAuthStore } from '~services/auth';
+import { styled } from '~styles/styled';
 
 type Credentials = {
   email: string;

--- a/src/app/(auth)/signup.tsx
+++ b/src/app/(auth)/signup.tsx
@@ -1,12 +1,12 @@
-import { useForm, Controller } from 'react-hook-form';
 import { t, Trans } from '@lingui/macro';
 import { useHeaderHeight } from '@react-navigation/elements';
+import { Controller, useForm } from 'react-hook-form';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 
-import { styled } from '~styles/styled';
-import { FillButton, Text, TextInput, Stack, Spacer } from '~components/uikit';
 import { showToast } from '~components/common/Toaster';
+import { FillButton, Spacer, Stack, Text, TextInput } from '~components/uikit';
 import { useAuthStore } from '~services/auth';
+import { styled } from '~styles/styled';
 
 type Credentials = {
   email: string;

--- a/src/app/(tabs)/_layout.tsx
+++ b/src/app/(tabs)/_layout.tsx
@@ -1,13 +1,13 @@
-import { StyleSheet } from 'react-native';
-import { Tabs } from 'expo-router';
 import { t } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
+import { Tabs } from 'expo-router';
+import { StyleSheet } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import StoreReview from '~components/store-review/StoreReview';
+import { Icon, Text } from '~components/uikit';
 import type { IconName } from '~components/uikit/Icon';
 import { useTheme } from '~styles';
-import { Icon, Text } from '~components/uikit';
 
 type TabList = {
   id: string;

--- a/src/app/(tabs)/profile.tsx
+++ b/src/app/(tabs)/profile.tsx
@@ -1,4 +1,5 @@
 import { Trans } from '@lingui/macro';
+
 import { Text } from '~components/uikit';
 import { styled } from '~styles';
 

--- a/src/app/(tabs)/search.tsx
+++ b/src/app/(tabs)/search.tsx
@@ -1,4 +1,5 @@
 import { Trans } from '@lingui/macro';
+
 import { Text } from '~components/uikit';
 import { styled } from '~styles';
 

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -1,9 +1,5 @@
-import { useEffect } from 'react';
-import { DevSettings } from 'react-native';
 import { useLingui } from '@lingui/react';
 import { registerDevMenuItems } from 'expo-dev-menu';
-import * as SplashScreen from 'expo-splash-screen';
-
 import {
   Stack,
   router,
@@ -11,13 +7,16 @@ import {
   useRouter,
   useSegments,
 } from 'expo-router';
+import * as SplashScreen from 'expo-splash-screen';
+import { useEffect } from 'react';
+import { DevSettings } from 'react-native';
 
 import Providers from '~Providers';
 import StatusBar from '~components/common/StatusBar';
-import { useAppReady } from '~utils/init';
-import { useDefaultStackScreenOptions } from '~utils/navigation';
 import { useAuthStore } from '~services/auth';
 import { useEffectEvent } from '~utils/common';
+import { useAppReady } from '~utils/init';
+import { useDefaultStackScreenOptions } from '~utils/navigation';
 
 if (__DEV__) {
   const devMenuItems = [

--- a/src/app/menu-list/[item].tsx
+++ b/src/app/menu-list/[item].tsx
@@ -1,7 +1,9 @@
-import { useEffect } from 'react';
 import { Stack, router, useLocalSearchParams } from 'expo-router';
-import { useMenuListItem } from '../(tabs)/settings';
+import { useEffect } from 'react';
+
 import { styled } from '~styles';
+
+import { useMenuListItem } from '../(tabs)/settings';
 
 export default function MenuListItem() {
   const { item } = useLocalSearchParams<{ item: string }>();

--- a/src/app/playground/_layout.tsx
+++ b/src/app/playground/_layout.tsx
@@ -1,4 +1,5 @@
 import { Stack } from 'expo-router';
+
 import { FillButton } from '~components/uikit';
 import { useColorMode } from '~services/color-mode';
 import { useDefaultStackScreenOptions } from '~utils/navigation';

--- a/src/app/playground/buttons.tsx
+++ b/src/app/playground/buttons.tsx
@@ -1,5 +1,3 @@
-import { styled } from '~styles';
-
 import {
   FillButton,
   IconButton,
@@ -7,6 +5,7 @@ import {
   Stack,
   Text,
 } from '~components/uikit';
+import { styled } from '~styles';
 
 export default function Buttons() {
   function handlePress() {

--- a/src/app/playground/inputs.tsx
+++ b/src/app/playground/inputs.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 
-import { styled } from '~styles';
 import {
   Checkbox,
   DateInput,
@@ -11,6 +10,7 @@ import {
   Text,
   TextInput,
 } from '~components/uikit';
+import { styled } from '~styles';
 
 export default function Inputs() {
   const [selectedMultiple, setSelectedMultiple] = useState<string[]>([]);

--- a/src/app/playground/sandbox.tsx
+++ b/src/app/playground/sandbox.tsx
@@ -1,5 +1,5 @@
+import { Stack, Text } from '~components/uikit';
 import { styled } from '~styles';
-import { Text, Stack } from '~components/uikit';
 
 export default function Sandbox() {
   return (

--- a/src/app/playground/toast.tsx
+++ b/src/app/playground/toast.tsx
@@ -1,6 +1,6 @@
-import { styled } from '~styles';
-import { FillButton, Stack, Text } from '~components/uikit';
 import { showToast } from '~components/common/Toaster';
+import { FillButton, Stack, Text } from '~components/uikit';
+import { styled } from '~styles';
 
 export default function Toast() {
   return (

--- a/src/components/common/ErrorBoundary.tsx
+++ b/src/components/common/ErrorBoundary.tsx
@@ -1,5 +1,5 @@
-import { Component, ReactNode } from 'react';
 import { Trans } from '@lingui/macro';
+import { Component, ReactNode } from 'react';
 
 import { Stack, Text } from '~components/uikit';
 import { styled } from '~styles';

--- a/src/components/common/LoadingScreen.tsx
+++ b/src/components/common/LoadingScreen.tsx
@@ -1,4 +1,5 @@
 import { ActivityIndicator } from 'react-native';
+
 import { styled, useTheme } from '~styles';
 
 export default function LoadingScreen() {

--- a/src/components/common/MenuList.tsx
+++ b/src/components/common/MenuList.tsx
@@ -1,7 +1,7 @@
+import { router } from 'expo-router';
 import { FunctionComponent, ReactNode, isValidElement } from 'react';
 import { Platform, StyleSheet } from 'react-native';
 
-import { router } from 'expo-router';
 import { Icon, Stack, Text } from '~components/uikit';
 import { styled } from '~styles';
 

--- a/src/components/common/NavigationThemeProvider.tsx
+++ b/src/components/common/NavigationThemeProvider.tsx
@@ -1,5 +1,5 @@
-import { ReactNode } from 'react';
 import { ThemeProvider } from '@react-navigation/native';
+import { ReactNode } from 'react';
 
 import { useColorMode } from '~services/color-mode';
 import { useTheme } from '~styles';

--- a/src/components/common/StatusBar.tsx
+++ b/src/components/common/StatusBar.tsx
@@ -1,4 +1,5 @@
 import { StatusBar as RNStatusBar } from 'react-native';
+
 import { useColorMode } from '~services/color-mode';
 import { useTheme } from '~styles/styled';
 

--- a/src/components/common/Toaster.tsx
+++ b/src/components/common/Toaster.tsx
@@ -1,9 +1,9 @@
-import ToastContainer, { ToastConfigParams } from 'react-native-toast-message';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import ToastContainer, { ToastConfigParams } from 'react-native-toast-message';
 
-import { styled, useTheme, Color } from '~styles/styled';
+import { Icon, Stack, Text } from '~components/uikit';
 import { IconName } from '~components/uikit/Icon';
-import { Stack, Text, Icon } from '~components/uikit';
+import { Color, styled, useTheme } from '~styles/styled';
 
 type Props = ToastConfigParams<{
   icon?: IconName;

--- a/src/components/store-review/ImprovementForm.tsx
+++ b/src/components/store-review/ImprovementForm.tsx
@@ -1,13 +1,13 @@
-import { useState } from 'react';
-import { ScrollView } from 'react-native';
 import { BottomSheetTextInput } from '@gorhom/bottom-sheet';
 import { Trans, t } from '@lingui/macro';
+import { useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
+import { ScrollView } from 'react-native';
 
+import { showToast } from '~components/common/Toaster';
 import { FillButton, IconButton, Stack, Text } from '~components/uikit';
 import { styled } from '~styles';
 import { sleep } from '~utils/common';
-import { showToast } from '~components/common/Toaster';
 
 type ImprovementFormType = {
   onCancel: () => void;

--- a/src/components/store-review/StoreReview.tsx
+++ b/src/components/store-review/StoreReview.tsx
@@ -1,9 +1,7 @@
-import { useEffect, useState } from 'react';
-import * as ExpoStoreReview from 'expo-store-review';
 import { Trans, t } from '@lingui/macro';
 import { differenceInDays } from 'date-fns';
-
-import { showToast } from '../common/Toaster';
+import * as ExpoStoreReview from 'expo-store-review';
+import { useEffect, useState } from 'react';
 
 import ImprovementForm from '~components/store-review/ImprovementForm';
 import {
@@ -13,8 +11,10 @@ import {
   Stack,
   Text,
 } from '~components/uikit';
-import storage from '~utils/storage';
 import { styled } from '~styles';
+import storage from '~utils/storage';
+
+import { showToast } from '../common/Toaster';
 
 const DAYS_TO_WAIT_BEFORE_ASKING_AGAIN = 7;
 const DAYS_BETWEEN_REVIEWS = 365;

--- a/src/components/uikit/BottomSheet.tsx
+++ b/src/components/uikit/BottomSheet.tsx
@@ -1,8 +1,8 @@
-import { ReactNode, forwardRef } from 'react';
 import RNBottomSheet, {
   BottomSheetBackdrop,
   BottomSheetProps as RNBottomSheetProps,
 } from '@gorhom/bottom-sheet';
+import { ReactNode, forwardRef } from 'react';
 
 import { styled, useTheme } from '~styles';
 

--- a/src/components/uikit/Image.tsx
+++ b/src/components/uikit/Image.tsx
@@ -1,4 +1,5 @@
 import FastImage, { FastImageProps } from 'react-native-fast-image';
+
 import { useImageDimensions } from '~utils/image';
 
 type Props = FastImageProps & {

--- a/src/components/uikit/PickerModal.tsx
+++ b/src/components/uikit/PickerModal.tsx
@@ -1,7 +1,5 @@
-import { MutableRefObject, useEffect, useRef, useState } from 'react';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Trans } from '@lingui/macro';
-
+import { MutableRefObject, useEffect, useRef, useState } from 'react';
 import {
   Animated,
   Easing,
@@ -10,12 +8,14 @@ import {
   TouchableWithoutFeedback,
   useWindowDimensions,
 } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { styled } from '~styles';
 
 import { Text } from './Text';
-import { Stack } from './layout/Stack';
-import { Radio } from './inputs/Radio';
 import { Checkbox } from './inputs/Checkbox';
-import { styled } from '~styles';
+import { Radio } from './inputs/Radio';
+import { Stack } from './layout/Stack';
 
 type BaseProps = {
   label: string;

--- a/src/components/uikit/PickerSheet.tsx
+++ b/src/components/uikit/PickerSheet.tsx
@@ -1,17 +1,18 @@
-import { memo, ReactNode, useState } from 'react';
-import { Modal, Platform } from 'react-native';
 import { Trans } from '@lingui/macro';
 import { FlashList } from '@shopify/flash-list';
+import { ReactNode, memo, useState } from 'react';
+import { Modal, Platform } from 'react-native';
 
-import { Text } from './Text';
-import { Stack } from './layout/Stack';
-import { Spacer } from './layout/Spacer';
-import { Radio } from './inputs/Radio';
-import { Checkbox } from './inputs/Checkbox';
-import { SearchInput } from './inputs/SearchInput';
+import StatusBar from '~components/common/StatusBar';
 import { styled } from '~styles';
 import { useEffectEvent } from '~utils/common';
-import StatusBar from '~components/common/StatusBar';
+
+import { Text } from './Text';
+import { Checkbox } from './inputs/Checkbox';
+import { Radio } from './inputs/Radio';
+import { SearchInput } from './inputs/SearchInput';
+import { Spacer } from './layout/Spacer';
+import { Stack } from './layout/Stack';
 
 type Option = {
   label: string;

--- a/src/components/uikit/SegmentedControl.tsx
+++ b/src/components/uikit/SegmentedControl.tsx
@@ -1,6 +1,5 @@
-import type { LayoutChangeEvent, LayoutRectangle } from 'react-native';
 import { Fragment, useState } from 'react';
-
+import type { LayoutChangeEvent, LayoutRectangle } from 'react-native';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
@@ -8,8 +7,9 @@ import Animated, {
   withSpring,
 } from 'react-native-reanimated';
 
-import { Text } from './Text';
 import { styled } from '~styles';
+
+import { Text } from './Text';
 
 type Props<T> = {
   segments: Array<{ value: T; label: string }>;

--- a/src/components/uikit/buttons/ButtonContent.tsx
+++ b/src/components/uikit/buttons/ButtonContent.tsx
@@ -1,11 +1,12 @@
 import { ReactNode } from 'react';
 import { ActivityIndicator } from 'react-native';
 
+import { Color, Typography, styled, useTheme } from '~styles';
+
+import { ButtonProps, ButtonSize, ButtonVariant } from './types';
 import { Icon } from '../Icon';
 import { Text } from '../Text';
 import { Stack } from '../layout/Stack';
-import type { ButtonProps, ButtonSize, ButtonVariant } from './types';
-import { Color, Typography, styled, useTheme } from '~styles';
 
 type Props = {
   children: ReactNode;

--- a/src/components/uikit/buttons/FillButton.tsx
+++ b/src/components/uikit/buttons/FillButton.tsx
@@ -1,6 +1,7 @@
-import type { ButtonProps } from './types';
-import ButtonContent from './ButtonContent';
 import { styled } from '~styles';
+
+import ButtonContent from './ButtonContent';
+import type { ButtonProps } from './types';
 
 export function FillButton({
   children,

--- a/src/components/uikit/buttons/IconButton.tsx
+++ b/src/components/uikit/buttons/IconButton.tsx
@@ -1,15 +1,15 @@
 import { ReactNode } from 'react';
 import { ActivityIndicator, PressableProps } from 'react-native';
-
 import Animated, {
-  withSpring,
-  useSharedValue,
   useAnimatedStyle,
+  useSharedValue,
+  withSpring,
   withTiming,
 } from 'react-native-reanimated';
 
+import { Color, styled, useTheme } from '~styles';
+
 import { Icon, IconName } from '../Icon';
-import { styled, useTheme, Color } from '~styles';
 
 type Size = 'small' | 'medium' | 'large';
 

--- a/src/components/uikit/buttons/OutlineButton.tsx
+++ b/src/components/uikit/buttons/OutlineButton.tsx
@@ -1,6 +1,7 @@
-import type { ButtonProps, ButtonVariant } from './types';
-import ButtonContent from './ButtonContent';
 import { Color, styled } from '~styles';
+
+import ButtonContent from './ButtonContent';
+import type { ButtonProps, ButtonVariant } from './types';
 
 export function OutlineButton({
   children,

--- a/src/components/uikit/buttons/types.ts
+++ b/src/components/uikit/buttons/types.ts
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import type { TouchableWithoutFeedbackProps } from 'react-native';
+
 import type { IconName } from '../Icon';
 
 export type ButtonSize = 'small' | 'medium' | 'large';

--- a/src/components/uikit/inputs/Checkbox.tsx
+++ b/src/components/uikit/inputs/Checkbox.tsx
@@ -1,14 +1,14 @@
 import { PixelRatio } from 'react-native';
-
 import Animated, {
   Easing,
   useAnimatedStyle,
   withTiming,
 } from 'react-native-reanimated';
 
-import { Text } from '../Text';
-import { Icon } from '../Icon';
 import { styled } from '~styles';
+
+import { Icon } from '../Icon';
+import { Text } from '../Text';
 
 type Props = {
   onChange: (value: string) => void;

--- a/src/components/uikit/inputs/DateInput.tsx
+++ b/src/components/uikit/inputs/DateInput.tsx
@@ -1,15 +1,16 @@
-import { Keyboard, Platform, ViewStyle } from 'react-native';
-import { forwardRef, useImperativeHandle, useState } from 'react';
 import { t } from '@lingui/macro';
 import { DateTime } from 'luxon';
+import { forwardRef, useImperativeHandle, useState } from 'react';
+import { Keyboard, Platform, ViewStyle } from 'react-native';
 import DatePicker from 'react-native-date-picker';
 
-import type { IconName } from '../Icon';
-import { Text } from '../Text';
-import { InputButton } from './InputButton';
-import { styled } from '~styles';
-import { useI18n } from '~services/i18n';
 import { useColorMode } from '~services/color-mode';
+import { useI18n } from '~services/i18n';
+import { styled } from '~styles';
+
+import { InputButton } from './InputButton';
+import { IconName } from '../Icon';
+import { Text } from '../Text';
 
 type Props = {
   label: string;

--- a/src/components/uikit/inputs/InputButton.tsx
+++ b/src/components/uikit/inputs/InputButton.tsx
@@ -1,9 +1,10 @@
 import { Animated, ViewStyle } from 'react-native';
 
-import { Text } from '../Text';
-import { Icon, IconName } from '../Icon';
-import { useInputLabelAnimation } from './common';
 import { styled } from '~styles';
+
+import { useInputLabelAnimation } from './common';
+import { Icon, IconName } from '../Icon';
+import { Text } from '../Text';
 
 type Props = {
   value?: string;

--- a/src/components/uikit/inputs/Radio.tsx
+++ b/src/components/uikit/inputs/Radio.tsx
@@ -1,8 +1,9 @@
-import { useRef, useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { Animated, PixelRatio } from 'react-native';
 
-import { Text } from '../Text';
 import { styled } from '~styles';
+
+import { Text } from '../Text';
 
 type Props = {
   onChange: (value: string) => void;

--- a/src/components/uikit/inputs/SearchInput.tsx
+++ b/src/components/uikit/inputs/SearchInput.tsx
@@ -1,11 +1,12 @@
+import { t, Trans } from '@lingui/macro';
 import { useRef, useState } from 'react';
 import { TextInputProps, TouchableOpacity } from 'react-native';
-import { t, Trans } from '@lingui/macro';
 
+import { styled } from '~styles';
+
+import { Icon } from '../Icon';
 import { Text } from '../Text';
 import { Stack } from '../layout/Stack';
-import { Icon } from '../Icon';
-import { styled } from '~styles';
 
 type Props = Omit<TextInputProps, 'onChange'> & {
   value: string;

--- a/src/components/uikit/inputs/Select.tsx
+++ b/src/components/uikit/inputs/Select.tsx
@@ -1,5 +1,3 @@
-import { Keyboard, ViewStyle } from 'react-native';
-
 import {
   ComponentProps,
   forwardRef,
@@ -7,13 +5,15 @@ import {
   useImperativeHandle,
   useState,
 } from 'react';
+import { Keyboard, ViewStyle } from 'react-native';
 
+import { styled } from '~styles';
+
+import { InputButton } from './InputButton';
 import type { IconName } from '../Icon';
-import { Text } from '../Text';
 import { PickerModal } from '../PickerModal';
 import { PickerSheet } from '../PickerSheet';
-import { InputButton } from './InputButton';
-import { styled } from '~styles';
+import { Text } from '../Text';
 
 type BaseProps = {
   options: Array<{ label: string; value: string }>;

--- a/src/components/uikit/inputs/TextInput.tsx
+++ b/src/components/uikit/inputs/TextInput.tsx
@@ -1,10 +1,11 @@
 import { forwardRef, useEffect, useState } from 'react';
 import { Animated, TextInputProps, TouchableOpacity } from 'react-native';
 
-import { Text } from '../Text';
-import { Icon } from '../Icon';
-import { useInputLabelAnimation } from './common';
 import { styled, useTheme } from '~styles';
+
+import { useInputLabelAnimation } from './common';
+import { Icon } from '../Icon';
+import { Text } from '../Text';
 
 type Props = Omit<TextInputProps, 'onChange'> & {
   value: string;

--- a/src/components/uikit/layout/Grid.tsx
+++ b/src/components/uikit/layout/Grid.tsx
@@ -1,8 +1,9 @@
 import { cloneElement, isValidElement, ReactNode, useState } from 'react';
 import { LayoutChangeEvent, View, ViewProps } from 'react-native';
 
-import { flattenChildren } from '../helpers';
 import { styled, Theme, useTheme } from '~styles';
+
+import { flattenChildren } from '../helpers';
 
 type Props = ViewProps & {
   spacing: keyof Theme['space'];

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -1,4 +1,5 @@
 import Constants from 'expo-constants';
+
 import type { Config } from '../../config/types';
 
 const config = Constants.expoConfig?.extra as Config;

--- a/src/services/auth.tsx
+++ b/src/services/auth.tsx
@@ -1,9 +1,9 @@
-import { unstable_batchedUpdates } from 'react-native'; // eslint-disable-line
 import { t } from '@lingui/macro';
+import { unstable_batchedUpdates } from 'react-native'; // eslint-disable-line
 import create from 'zustand';
 
-import storage from '~utils/storage';
 import { showToast } from '~components/common/Toaster';
+import storage from '~utils/storage';
 
 type AuthStatus =
   | 'undetermined'

--- a/src/services/i18n.tsx
+++ b/src/services/i18n.tsx
@@ -1,8 +1,8 @@
-import { ReactNode } from 'react';
-import { getLocales } from 'react-native-localize';
-import { Settings } from 'luxon';
 import { i18n } from '@lingui/core';
 import { I18nProvider as LinguiProvider, useLingui } from '@lingui/react';
+import { Settings } from 'luxon';
+import { ReactNode } from 'react';
+import { getLocales } from 'react-native-localize';
 
 import { useEffectEvent } from '~utils/common';
 import storage from '~utils/storage';

--- a/src/services/permissions.tsx
+++ b/src/services/permissions.tsx
@@ -1,20 +1,19 @@
-import { useCallback } from 'react';
-import { Platform, Alert } from 'react-native';
 import { t } from '@lingui/macro';
-import create from 'zustand';
-import flatten from 'lodash/flatten';
 import compact from 'lodash/compact';
-
+import flatten from 'lodash/flatten';
+import { useCallback } from 'react';
+import { Alert, Platform } from 'react-native';
 import {
-  RESULTS,
-  openSettings,
-  checkMultiple,
-  checkNotifications,
-  requestMultiple,
-  requestNotifications,
   PERMISSIONS,
   Permission,
+  RESULTS,
+  checkMultiple,
+  checkNotifications,
+  openSettings,
+  requestMultiple,
+  requestNotifications,
 } from 'react-native-permissions';
+import create from 'zustand';
 
 import { useAppState } from '~utils/observe';
 

--- a/src/styles/helpers.ts
+++ b/src/styles/helpers.ts
@@ -1,5 +1,5 @@
-import * as typographyTokens from '../design-system/typography';
 import { theme, Theme } from './styled';
+import * as typographyTokens from '../design-system/typography';
 
 type Typography = keyof typeof typographyTokens;
 type ThemeKey = keyof Theme;

--- a/src/styles/styled.ts
+++ b/src/styles/styled.ts
@@ -2,13 +2,13 @@ import { StyleSheet } from 'react-native';
 import type * as Stitches from 'stitches-native';
 import { createStitches } from 'stitches-native';
 
-import * as utils from './utils';
-
 import * as colors from '~design-system/colors';
 import * as radii from '~design-system/radii';
 import space from '~design-system/spacing.json';
 import * as typography from '~design-system/typography';
 import * as designSystemUtils from '~design-system/utils';
+
+import * as utils from './utils';
 
 const { styled, css, createTheme, config, theme, useTheme, ThemeProvider } =
   createStitches({

--- a/src/utils/init.ts
+++ b/src/utils/init.ts
@@ -1,11 +1,12 @@
-import { useEffect, useState } from 'react';
 import { useNavigationContainerRef } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
+import { useEffect, useState } from 'react';
 
-import { useFontsReady } from './font';
-import { sleep } from './common';
 import { initAuth } from '~services/auth';
 import { initMessages } from '~services/i18n';
+
+import { sleep } from './common';
+import { useFontsReady } from './font';
 
 export function useAppReady() {
   const initReady = useInitReady();

--- a/src/utils/linking.ts
+++ b/src/utils/linking.ts
@@ -1,5 +1,6 @@
 import { t } from '@lingui/macro';
 import { Linking } from 'react-native';
+
 import { showToast } from '~components/common/Toaster';
 
 export async function launchUrl(

--- a/src/utils/navigation.tsx
+++ b/src/utils/navigation.tsx
@@ -1,11 +1,10 @@
-import { useEffect } from 'react';
-import { StackNavigationOptions } from '@react-navigation/stack';
-import { NativeStackNavigationOptions } from '@react-navigation/native-stack';
-
 import { t } from '@lingui/macro';
-
-import { useNavigation } from 'expo-router';
 import { NavigationState, PartialState } from '@react-navigation/native';
+import { NativeStackNavigationOptions } from '@react-navigation/native-stack';
+import { StackNavigationOptions } from '@react-navigation/stack';
+import { useNavigation } from 'expo-router';
+import { useEffect } from 'react';
+
 import { useTheme } from '~styles';
 
 export function getActiveRouteName(

--- a/src/utils/observe.tsx
+++ b/src/utils/observe.tsx
@@ -1,6 +1,7 @@
+import { useIsFocused } from '@react-navigation/native';
 import { useEffect, useRef, useState } from 'react';
 import { AppState, AppStateStatus, BackHandler, Keyboard } from 'react-native';
-import { useIsFocused } from '@react-navigation/native';
+
 import { useEffectEvent } from './common';
 
 export function useKeyboardVisibility() {

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,5 +1,4 @@
 import isObject from 'lodash/isObject';
-
 import {
   MMKV,
   useMMKVBoolean,


### PR DESCRIPTION
Improved the `"import/order"` in the `.eslintrc` file to get automatic organisation of imports. 

**Tip**: To get VSC to automatically apply the changes, add this to your VSC settings:

```  
"[typescriptreact]": {
    "editor.defaultFormatter": "esbenp.prettier-vscode",
      "editor.codeActionsOnSave": {
        "source.organizeImports": "explicit",
        "source.removeUnusedImports": "explicit",
        "source.fixAll": "explicit"
      }
 }
  ```