### PR TITLE
Support Environment-Based URL Schemes & Unique Storage Keys

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -18,7 +18,7 @@ const appId = `com.taito.template${config.appIdSuffix ?? ''}`;
 const expoConfig: ExpoConfig = {
   slug: 'taito-template',
   name: 'Taito Template',
-  scheme: 'taito-template',
+  scheme: config.scheme,
   owner: 'taito-united',
   version: '1.0.0',
   orientation: 'portrait',

--- a/config/dev.config.ts
+++ b/config/dev.config.ts
@@ -1,8 +1,9 @@
-import { Config } from './types';
 import * as colors from '../src/design-system/colors';
+import { Config } from './types';
 
 export const config: Config = {
   appEnv: 'dev',
+  scheme: 'taito-template-dev',
   apiUrl: 'https://api.example.com',
   appIdSuffix: '.dev', // NOTE: dev/test/stag share the same app id!
   iconImage: './src/design-system/assets/icon.png',

--- a/config/prod.config.ts
+++ b/config/prod.config.ts
@@ -1,8 +1,9 @@
-import { Config } from './types';
 import * as colors from '../src/design-system/colors';
+import { Config } from './types';
 
 export const config: Config = {
   appEnv: 'prod',
+  scheme: 'taito-template',
   apiUrl: 'https://api.example.com',
   iconImage: './src/design-system/assets/icon.png',
   adaptiveIcon: {

--- a/config/stag.config.ts
+++ b/config/stag.config.ts
@@ -1,8 +1,9 @@
-import { Config } from './types';
 import * as colors from '../src/design-system/colors';
+import { Config } from './types';
 
 export const config: Config = {
   appEnv: 'stag',
+  scheme: 'taito-template-stag',
   apiUrl: 'https://api.example.com',
   appIdSuffix: '.dev', // NOTE: dev/test/stag share the same app id!
   iconImage: './src/design-system/assets/icon-stag.png',

--- a/config/test.config.ts
+++ b/config/test.config.ts
@@ -1,8 +1,9 @@
-import { Config } from './types';
 import * as colors from '../src/design-system/colors';
+import { Config } from './types';
 
 export const config: Config = {
   appEnv: 'test',
+  scheme: 'taito-template-test',
   apiUrl: 'https://api.example.com',
   appIdSuffix: '.dev', // NOTE: dev/test/stag share the same app id!
   iconImage: './src/design-system/assets/icon-test.png',

--- a/config/types.ts
+++ b/config/types.ts
@@ -1,5 +1,6 @@
 export type Config = {
   appEnv: 'dev' | 'test' | 'stag' | 'prod';
+  scheme: string;
   apiUrl: string;
   appIdSuffix?: string;
   iconImage: string;

--- a/src/components/store-review/StoreReview.tsx
+++ b/src/components/store-review/StoreReview.tsx
@@ -7,10 +7,7 @@ import ImprovementForm from '~components/store-review/ImprovementForm';
 import { BottomSheet, Button, Stack, Text } from '~components/uikit';
 import { useI18n } from '~services/i18n';
 import { styled } from '~styles';
-import storage, {
-  APP_REVIEW_DONE_STORAGE_KEY,
-  APP_REVIEW_LAST_REQUESTED_STORAGE_KEY,
-} from '~utils/storage';
+import storage, { STORAGE_KEYS } from '~utils/storage';
 
 import { showToast } from '../common/Toaster';
 
@@ -23,12 +20,14 @@ export default function StoreReview() {
   const [improvementRequest, setImprovementRequest] = useState(false);
 
   useEffect(() => {
-    const persistedHasReviewed = storage.getNumber(APP_REVIEW_DONE_STORAGE_KEY);
+    const persistedHasReviewed = storage.getNumber(
+      STORAGE_KEYS.APP_REVIEW_DONE
+    );
     const getReviewDate = async () => {
       try {
         if (await ExpoStoreReview.hasAction()) {
           const persistedLastAsked = storage.getNumber(
-            APP_REVIEW_LAST_REQUESTED_STORAGE_KEY
+            STORAGE_KEYS.APP_REVIEW_LAST_REQUESTED
           );
           if (persistedLastAsked) {
             const differenceInDaysValue = differenceInDays(
@@ -66,14 +65,14 @@ export default function StoreReview() {
   }, []);
 
   const updateLastAsked = () => {
-    storage.set(APP_REVIEW_LAST_REQUESTED_STORAGE_KEY, new Date().getTime());
+    storage.set(STORAGE_KEYS.APP_REVIEW_LAST_REQUESTED, new Date().getTime());
   };
 
   async function requestReview() {
     try {
       if (await ExpoStoreReview.hasAction()) {
         await ExpoStoreReview.requestReview();
-        storage.set(APP_REVIEW_DONE_STORAGE_KEY, new Date().getTime());
+        storage.set(STORAGE_KEYS.APP_REVIEW_DONE, new Date().getTime());
       }
     } catch (error) {
       console.log('> Error requesting review: ', error);

--- a/src/services/auth.tsx
+++ b/src/services/auth.tsx
@@ -4,10 +4,7 @@ import { unstable_batchedUpdates } from 'react-native'; // eslint-disable-line
 import { create } from 'zustand';
 
 import { showToast } from '~components/common/Toaster';
-import storage, {
-  ACCESS_TOKEN_STORAGE_KEY,
-  REFRESH_TOKEN_STORAGE_KEY,
-} from '~utils/storage';
+import storage, { STORAGE_KEYS } from '~utils/storage';
 
 type AuthStatus =
   | 'undetermined'
@@ -85,7 +82,7 @@ export async function initAuth() {
   authStore.setState({ status: 'determining' });
 
   try {
-    const accessToken = storage.getString(ACCESS_TOKEN_STORAGE_KEY);
+    const accessToken = storage.getString(STORAGE_KEYS.ACCESS_TOKEN);
 
     if (!accessToken) {
       throw Error('No access token!');
@@ -123,8 +120,8 @@ function setAuthTokens({
   refreshToken: string;
 }) {
   storage.clearAll();
-  storage.set(ACCESS_TOKEN_STORAGE_KEY, accessToken);
-  storage.set(REFRESH_TOKEN_STORAGE_KEY, refreshToken);
+  storage.set(STORAGE_KEYS.ACCESS_TOKEN, accessToken);
+  storage.set(STORAGE_KEYS.REFRESH_TOKEN, refreshToken);
 }
 
 export function isAuthError(error: any) {

--- a/src/services/color-mode.tsx
+++ b/src/services/color-mode.tsx
@@ -2,7 +2,7 @@ import { ReactNode, createContext, useContext } from 'react';
 import { ColorSchemeName, useColorScheme } from 'react-native';
 
 import { ThemeProvider, darkTheme, theme as lightTheme } from '~styles';
-import { COLOR_MODE_STORAGE_KEY, useStorageString } from '~utils/storage';
+import { STORAGE_KEYS, useStorageString } from '~utils/storage';
 
 type ColorMode = 'light' | 'dark' | 'system';
 type ColorScheme = 'light' | 'dark';
@@ -23,7 +23,7 @@ const getColorScheme = (c: ColorSchemeName): ColorScheme =>
 export function ColorModeProvider({ children }: { children: ReactNode }) {
   const systemColorMode = useColorScheme();
   const [persistedColorMode, setPersistedColorMode] = useStorageString(
-    COLOR_MODE_STORAGE_KEY
+    STORAGE_KEYS.COLOR_MODE
   );
 
   const colorMode = (persistedColorMode || 'system') as ColorMode;

--- a/src/services/i18n.tsx
+++ b/src/services/i18n.tsx
@@ -4,14 +4,14 @@ import { Settings } from 'luxon';
 import { getLocales } from 'react-native-localize';
 
 import { useEffectEvent } from '~utils/common';
-import storage, { LOCALE_STORAGE_KEY } from '~utils/storage';
+import storage, { STORAGE_KEYS } from '~utils/storage';
 
 export type Locale = 'fi' | 'en';
 const LOCALES: Locale[] = ['fi', 'en'];
 
 export async function initMessages() {
   const locales = getLocales();
-  const persistedLocale = storage.getString(LOCALE_STORAGE_KEY) as Locale;
+  const persistedLocale = storage.getString(STORAGE_KEYS.LOCALE) as Locale;
   const preferredLocale = locales[0];
   const defaultLocale: Locale = LOCALES.includes(persistedLocale)
     ? persistedLocale
@@ -22,7 +22,7 @@ export async function initMessages() {
   const defaultMessages = await loadMessages(defaultLocale);
 
   i18n.loadAndActivate({ locale: defaultLocale, messages: defaultMessages });
-  storage.set(LOCALE_STORAGE_KEY, defaultLocale);
+  storage.set(STORAGE_KEYS.LOCALE, defaultLocale);
   Settings.defaultLocale = defaultLocale;
 }
 
@@ -47,7 +47,7 @@ export function useI18n() {
       i18n.loadAndActivate({ locale, messages: newMessages });
 
       Settings.defaultLocale = locale;
-      storage.set(LOCALE_STORAGE_KEY, locale);
+      storage.set(STORAGE_KEYS.LOCALE, locale);
     } catch (error) {
       console.log(`> Failed to load messages for locale: ${locale}`, error);
     }

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -7,26 +7,32 @@ import {
   useMMKVString,
 } from 'react-native-mmkv';
 
-export const LOCALE_STORAGE_KEY = '@app/locale';
-export const ACCESS_TOKEN_STORAGE_KEY = '@app/access-token';
-export const REFRESH_TOKEN_STORAGE_KEY = '@app/refresh-token';
-export const COLOR_MODE_STORAGE_KEY = '@app/color-mode';
-export const APP_REVIEW_LAST_REQUESTED_STORAGE_KEY =
-  '@app/last-requested-review';
-export const APP_REVIEW_DONE_STORAGE_KEY = '@app/last-review-done';
+import config from '~constants/config';
 
-// Add all storage keys here so that they can be cleared upon logout
+const createStorageKey = (key: string) => `@${config.scheme}/${key}`;
+
+// Add all your storage keys here
+export const STORAGE_KEYS = {
+  LOCALE: createStorageKey('locale'),
+  ACCESS_TOKEN: createStorageKey('access-token'),
+  REFRESH_TOKEN: createStorageKey('refresh-token'),
+  COLOR_MODE: createStorageKey('color-mode'),
+  APP_REVIEW_LAST_REQUESTED: createStorageKey('last-requested-review'),
+  APP_REVIEW_DONE: createStorageKey('last-review-done'),
+};
+
+// Add all clearable storage keys here so they can be cleared on logout
 const CLEARABLE_KEYS = [
-  ACCESS_TOKEN_STORAGE_KEY,
-  REFRESH_TOKEN_STORAGE_KEY,
+  STORAGE_KEYS.ACCESS_TOKEN,
+  STORAGE_KEYS.REFRESH_TOKEN,
 ] as const;
 
-// These storage keys should be persisted across logins, eg. showing some guided tours etc.
+// These storage keys should be persisted across logins, e.g. showing some guided tours, etc.
 const PERSISTENT_KEYS = [
-  LOCALE_STORAGE_KEY,
-  COLOR_MODE_STORAGE_KEY,
-  APP_REVIEW_DONE_STORAGE_KEY,
-  APP_REVIEW_LAST_REQUESTED_STORAGE_KEY,
+  STORAGE_KEYS.LOCALE,
+  STORAGE_KEYS.COLOR_MODE,
+  STORAGE_KEYS.APP_REVIEW_DONE,
+  STORAGE_KEYS.APP_REVIEW_LAST_REQUESTED,
 ] as const;
 
 const clearableStorage = new MMKV({ id: 'clearable' });


### PR DESCRIPTION
## ✨ What has changed?

This PR makes the URL scheme environment-specific, rather than using a single scheme across all environments.

> **Note:** URL schemes enable deep linking to the app. For example, with a scheme like `taito-template`, URLs such as `taito-template://` will open the app when tapped.

## 📝 Why these changes?

### 1. **Support for Multiple Environments**

By making the scheme environment-based, we can better manage deep linking across different environments. This allows us to use unique schemes such as:

- `taito-template://` for production
- `taito-template-test://` for testing
- `taito-template-dev://` for development

This prevents conflicts when switching between environments.

### 2. **Improved Storage Key Management**

The scheme is now accessible from `~constants/config.ts`, enabling its use in naming storage keys. Previously, many apps used the showcased `@app/storage_key_name` format, which risks conflicts if multiple apps based on the same template are installed on the same device.

By incorporating the environment into the storage key names, each app will now have unique storage keys per environment, avoiding potential data collisions.

### 3. **Code > Documentation**

Instead of relying solely on documentation to prevent storage key conflicts, this change directly addresses the issue in the codebase, ensuring environment-based separation automatically and reducing the risk of developer error.
