### PR TITLE
Add option for customizable bottom bar layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@lingui/core": "4.14.0",
         "@lingui/react": "4.14.0",
         "@react-native-menu/menu": "1.1.6",
+        "@react-navigation/drawer": "7.0.12",
         "@react-navigation/native": "^7.0.0",
         "@shopify/flash-list": "1.7.1",
         "expo": "~52.0.7",
@@ -5544,6 +5545,26 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/@react-navigation/drawer": {
+      "version": "7.0.12",
+      "resolved": "https://registry.npmjs.org/@react-navigation/drawer/-/drawer-7.0.12.tgz",
+      "integrity": "sha512-uXCxtIfnVy2IbnPUKzAo5IdMEXoQ/TRgjjOpJw/EEAN1I9nZs8yEUGgzYCkAPfVUAM74HYE4RJhcc19ErtgYwA==",
+      "dependencies": {
+        "@react-navigation/elements": "^2.1.6",
+        "color": "^4.2.3",
+        "react-native-drawer-layout": "^4.0.2",
+        "use-latest-callback": "^0.2.1"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^7.0.7",
+        "react": ">= 18.2.0",
+        "react-native": "*",
+        "react-native-gesture-handler": ">= 2.0.0",
+        "react-native-reanimated": ">= 2.0.0",
+        "react-native-safe-area-context": ">= 4.0.0",
+        "react-native-screens": ">= 4.0.0"
       }
     },
     "node_modules/@react-navigation/elements": {
@@ -15869,6 +15890,20 @@
       "peerDependencies": {
         "react": ">= 17.0.1",
         "react-native": ">= 0.64.3"
+      }
+    },
+    "node_modules/react-native-drawer-layout": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/react-native-drawer-layout/-/react-native-drawer-layout-4.0.2.tgz",
+      "integrity": "sha512-VkDpOquZQ+R2JkC9dRIO0NZrJSqRl3h/ryG+S23m3G2EenXVAXho/JuAhuM1LgO9sQuiu0hmgnOfa48ghufsfg==",
+      "dependencies": {
+        "use-latest-callback": "^0.2.1"
+      },
+      "peerDependencies": {
+        "react": ">= 18.2.0",
+        "react-native": "*",
+        "react-native-gesture-handler": ">= 2.0.0",
+        "react-native-reanimated": ">= 2.0.0"
       }
     },
     "node_modules/react-native-gesture-handler": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@lingui/core": "4.14.0",
     "@lingui/react": "4.14.0",
     "@react-native-menu/menu": "1.1.6",
+    "@react-navigation/drawer": "7.0.12",
     "@react-navigation/native": "^7.0.0",
     "@shopify/flash-list": "1.7.1",
     "expo": "~52.0.7",

--- a/src/app/(tabs)/_layout.tsx
+++ b/src/app/(tabs)/_layout.tsx
@@ -1,4 +1,5 @@
 import { msg } from '@lingui/macro';
+import { type BottomTabBarProps } from '@react-navigation/bottom-tabs';
 import { Tabs } from 'expo-router';
 import { StyleSheet } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -158,11 +159,15 @@ function DefaultBottomBar({ tabs, theme }: BottomBarProps) {
   );
 }
 
+function renderBottomBar(props: BottomTabBarProps & { tabs: TabList }) {
+  return <BottomBar {...props} />;
+}
+
 function CustomBottomBar({ tabs, theme }: BottomBarProps) {
   return (
     <Tabs
       initialRouteName="home"
-      tabBar={(props) => <BottomBar {...props} tabs={tabs} />}
+      tabBar={(props) => renderBottomBar({ ...props, tabs })}
       screenOptions={{
         headerStyle: {
           backgroundColor: theme.colors.surface,

--- a/src/app/(tabs)/_layout.tsx
+++ b/src/app/(tabs)/_layout.tsx
@@ -3,22 +3,33 @@ import { Tabs } from 'expo-router';
 import { StyleSheet } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
+import { BottomBar } from '~components/common/custom-bottom-bar/BottomBar';
 import StoreReview from '~components/store-review/StoreReview';
 import { Icon, Text } from '~components/uikit';
 import type { IconName } from '~components/uikit/Icon';
 import { useI18n } from '~services/i18n';
 import { useTheme } from '~styles';
 
-type TabList = {
+export type TabList = {
   id: string;
   title: string;
   iconFilled: IconName;
   iconOutlined: IconName;
 }[];
 
+/**
+ * Determines whether to use a fully customizable bottom tab bar (`CustomBottomBar`)
+ * or the default tab layout with minimal customization (`DefaultBottomBar`).
+ *
+ * Set `USE_CUSTOM_TABS` to `true` if the client requires a highly customizable tab bar (animations, unique styling, etc.).
+ * Set it to `false` to use the default tab setup, which applies simpler, standard styling.
+ *
+ * Example: For a custom bottom bar based on specific branding needs, set `USE_CUSTOM_TABS = true`.
+ */
+const USE_CUSTOM_TABS = true;
+
 export default function TabsLayout() {
   const { _ } = useI18n();
-  const insets = useSafeAreaInsets();
 
   const theme = useTheme();
   const tabs: TabList = [
@@ -49,6 +60,27 @@ export default function TabsLayout() {
       iconOutlined: 'settings',
     },
   ];
+
+  return (
+    <>
+      {USE_CUSTOM_TABS ? (
+        <CustomBottomBar tabs={tabs} theme={theme} />
+      ) : (
+        <DefaultBottomBar tabs={tabs} theme={theme} />
+      )}
+      <StoreReview />
+    </>
+  );
+}
+
+type BottomBarProps = {
+  tabs: TabList;
+  theme: ReturnType<typeof useTheme>;
+};
+
+function DefaultBottomBar({ tabs, theme }: BottomBarProps) {
+  const { _ } = useI18n();
+  const insets = useSafeAreaInsets();
 
   function renderTabIcon({
     focused,
@@ -83,48 +115,71 @@ export default function TabsLayout() {
   }
 
   return (
-    <>
-      <Tabs
-        initialRouteName="home"
-        screenOptions={{
-          headerStyle: {
-            backgroundColor: theme.colors.surface,
-          },
-          headerTintColor: theme.colors.text,
-          headerBackgroundContainerStyle: {
-            borderBottomColor: theme.colors.line3,
-            borderBottomWidth: StyleSheet.hairlineWidth,
-          },
-          headerTitleStyle: {
-            fontSize: theme.fontSizes.bodyBold,
-          },
-          tabBarStyle: {
-            backgroundColor: theme.colors.surface,
-            borderTopColor: theme.colors.line3,
-            borderTopWidth: StyleSheet.hairlineWidth,
-          },
-        }}
-      >
-        {tabs.map(({ id, title, iconFilled, iconOutlined }) => (
-          <Tabs.Screen
-            key={title}
-            name={id}
-            options={{
-              title,
-              tabBarAccessibilityLabel: _(msg`${title} tab`),
-              tabBarItemStyle: {
-                // On certain devices without insets, the tab bar is too close to the bottom of the screen
-                paddingBottom: insets.bottom === 0 ? 4 : 0,
-              },
-              tabBarLabel: ({ focused }) =>
-                renderBarLabel({ focused, id, title }),
-              tabBarIcon: ({ focused }) =>
-                renderTabIcon({ focused, iconFilled, iconOutlined }),
-            }}
-          />
-        ))}
-      </Tabs>
-      <StoreReview />
-    </>
+    <Tabs
+      initialRouteName="home"
+      screenOptions={{
+        headerStyle: {
+          backgroundColor: theme.colors.surface,
+        },
+        headerTintColor: theme.colors.text,
+        headerBackgroundContainerStyle: {
+          borderBottomColor: theme.colors.line3,
+          borderBottomWidth: StyleSheet.hairlineWidth,
+        },
+        headerTitleStyle: {
+          fontSize: theme.fontSizes.bodyBold,
+        },
+        tabBarStyle: {
+          backgroundColor: theme.colors.surface,
+          borderTopColor: theme.colors.line3,
+          borderTopWidth: StyleSheet.hairlineWidth,
+        },
+      }}
+    >
+      {tabs.map(({ id, title, iconFilled, iconOutlined }) => (
+        <Tabs.Screen
+          key={title}
+          name={id}
+          options={{
+            title,
+            tabBarAccessibilityLabel: _(msg`${title} tab`),
+            tabBarItemStyle: {
+              // On certain devices without insets, the tab bar is too close to the bottom of the screen
+              paddingBottom: insets.bottom === 0 ? 4 : 0,
+            },
+            tabBarLabel: ({ focused }) =>
+              renderBarLabel({ focused, id, title }),
+            tabBarIcon: ({ focused }) =>
+              renderTabIcon({ focused, iconFilled, iconOutlined }),
+          }}
+        />
+      ))}
+    </Tabs>
+  );
+}
+
+function CustomBottomBar({ tabs, theme }: BottomBarProps) {
+  return (
+    <Tabs
+      initialRouteName="home"
+      tabBar={(props) => <BottomBar {...props} tabs={tabs} />}
+      screenOptions={{
+        headerStyle: {
+          backgroundColor: theme.colors.surface,
+        },
+        headerTintColor: theme.colors.text,
+        headerBackgroundContainerStyle: {
+          borderBottomColor: theme.colors.line3,
+          borderBottomWidth: StyleSheet.hairlineWidth,
+        },
+        headerTitleStyle: {
+          fontSize: theme.fontSizes.bodyBold,
+        },
+      }}
+    >
+      {tabs.map(({ id, title }) => (
+        <Tabs.Screen key={title} name={id} options={{ title }} />
+      ))}
+    </Tabs>
   );
 }

--- a/src/app/(tabs)/_layout.web.tsx
+++ b/src/app/(tabs)/_layout.web.tsx
@@ -1,0 +1,96 @@
+import { msg } from '@lingui/macro';
+import { Drawer } from 'expo-router/drawer';
+import { StyleSheet } from 'react-native';
+
+import { Icon, type IconName } from '~components/uikit/Icon';
+import { useI18n } from '~services/i18n';
+import { useTheme } from '~styles';
+
+import { type TabList as DrawerList } from './_layout';
+
+export default function DrawerLayout() {
+  const { _ } = useI18n();
+
+  const theme = useTheme();
+
+  // Note: the items are intentionally 'duplicated' from the tabs list as we assume they will differ from each other in a real project.
+  const drawerItems: DrawerList = [
+    {
+      id: 'home',
+      title: _(msg`Home`),
+      iconFilled: 'homeFilled',
+      iconOutlined: 'home',
+    },
+    {
+      id: 'search',
+      title: _(msg`Search`),
+      iconFilled: 'search',
+      iconOutlined: 'search',
+    },
+
+    {
+      id: 'profile',
+      title: _(msg`Profile`),
+      iconFilled: 'personCircleFilled',
+      iconOutlined: 'personCircle',
+    },
+
+    {
+      id: 'settings',
+      title: _(msg`Settings`),
+      iconFilled: 'settingsFilled',
+      iconOutlined: 'settings',
+    },
+  ];
+
+  function renderDrawerIcon({
+    focused,
+    iconFilled,
+    iconOutlined,
+  }: {
+    focused: boolean;
+    iconFilled: IconName;
+    iconOutlined: IconName;
+  }) {
+    return <Icon name={focused ? iconFilled : iconOutlined} color="text" />;
+  }
+
+  return (
+    <Drawer
+      initialRouteName="home"
+      screenOptions={{
+        headerStyle: {
+          backgroundColor: theme.colors.surface,
+        },
+        headerTintColor: theme.colors.text,
+        headerBackgroundContainerStyle: {
+          borderBottomColor: theme.colors.line3,
+          borderBottomWidth: StyleSheet.hairlineWidth,
+        },
+        headerTitleStyle: {
+          fontSize: theme.fontSizes.bodyBold,
+        },
+        drawerStyle: {
+          backgroundColor: theme.colors.surface,
+        },
+      }}
+    >
+      {drawerItems.map(({ id, title, iconFilled, iconOutlined }) => (
+        <Drawer.Screen
+          key={title}
+          name={id}
+          options={{
+            title,
+            drawerLabel: title,
+            drawerActiveTintColor: theme.colors.text,
+            drawerItemStyle: {
+              borderRadius: theme.radii.regular,
+            },
+            drawerIcon: ({ focused }) =>
+              renderDrawerIcon({ focused, iconFilled, iconOutlined }),
+          }}
+        />
+      ))}
+    </Drawer>
+  );
+}

--- a/src/components/common/custom-bottom-bar/BottomBar.tsx
+++ b/src/components/common/custom-bottom-bar/BottomBar.tsx
@@ -1,7 +1,7 @@
-import { BottomTabBarProps } from '@react-navigation/bottom-tabs';
+import { type BottomTabBarProps } from '@react-navigation/bottom-tabs';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { TabList } from '~app/(tabs)/_layout';
+import { type TabList } from '~app/(tabs)/_layout';
 import { styled } from '~styles';
 
 import { TabBarButton } from './Tab';

--- a/src/components/common/custom-bottom-bar/BottomBar.tsx
+++ b/src/components/common/custom-bottom-bar/BottomBar.tsx
@@ -4,7 +4,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { TabList } from '~app/(tabs)/_layout';
 import { styled } from '~styles';
 
-import { TabButton } from './Tab';
+import { TabBarButton } from './Tab';
 
 type CustomTabBarProps = Pick<
   BottomTabBarProps,
@@ -50,7 +50,7 @@ export function BottomBar({
           navigation.emit({ type: 'tabLongPress', target: route.key });
 
         return (
-          <TabButton
+          <TabBarButton
             key={route.key}
             isFocused={isFocused}
             onPress={onPress}

--- a/src/components/common/custom-bottom-bar/BottomBar.tsx
+++ b/src/components/common/custom-bottom-bar/BottomBar.tsx
@@ -1,0 +1,73 @@
+import { BottomTabBarProps } from '@react-navigation/bottom-tabs';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { TabList } from '~app/(tabs)/_layout';
+import { styled } from '~styles';
+
+import { TabButton } from './Tab';
+
+type CustomTabBarProps = Pick<
+  BottomTabBarProps,
+  'state' | 'descriptors' | 'navigation'
+> & {
+  tabs: TabList;
+};
+
+const EXCLUDED_ROUTES = ['_sitemap', '+not-found'];
+
+export function BottomBar({
+  state,
+  descriptors,
+  navigation,
+  tabs,
+}: CustomTabBarProps) {
+  const insets = useSafeAreaInsets();
+
+  return (
+    <TabBarContainer style={{ paddingBottom: insets.bottom }}>
+      {state.routes.map((route, index) => {
+        if (EXCLUDED_ROUTES.includes(route.name)) return null;
+
+        const { options } = descriptors[route.key];
+        const label =
+          options.tabBarLabel !== undefined
+            ? (options.tabBarLabel as string)
+            : options.title || route.name;
+
+        const isFocused = state.index === index;
+        const onPress = () => {
+          const event = navigation.emit({
+            type: 'tabPress',
+            target: route.key,
+            canPreventDefault: true,
+          });
+          if (!isFocused && !event.defaultPrevented) {
+            navigation.navigate(route.name, route.params);
+          }
+        };
+
+        const onLongPress = () =>
+          navigation.emit({ type: 'tabLongPress', target: route.key });
+
+        return (
+          <TabButton
+            key={route.key}
+            isFocused={isFocused}
+            onPress={onPress}
+            onLongPress={onLongPress}
+            label={label}
+            tab={tabs[index]}
+          />
+        );
+      })}
+    </TabBarContainer>
+  );
+}
+
+const TabBarContainer = styled('View', {
+  display: 'flex',
+  flexDirection: 'row',
+  backgroundColor: '$surface',
+  paddingVertical: '$xs',
+  shadow: 'small',
+});

--- a/src/components/common/custom-bottom-bar/Tab.tsx
+++ b/src/components/common/custom-bottom-bar/Tab.tsx
@@ -1,5 +1,5 @@
 import { msg } from '@lingui/macro';
-import { memo, useMemo } from 'react';
+import { useEffect } from 'react';
 import { Pressable } from 'react-native';
 import Animated, {
   interpolate,
@@ -24,12 +24,12 @@ type TabBarButtonProps = {
   tab: TabList[number];
 };
 
-const TabBarButton = ({
+export function TabBarButton({
   isFocused,
   label,
   tab,
   ...pressableProps
-}: TabBarButtonProps) => {
+}: TabBarButtonProps) {
   const { _ } = useI18n();
   const iconScale = useSharedValue(isFocused ? 1 : 0);
   const labelOpacity = useSharedValue(isFocused ? 1 : 0);
@@ -43,7 +43,7 @@ const TabBarButton = ({
     });
   };
 
-  useMemo(() => updateFocusAnimation(isFocused), [isFocused]); // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(() => updateFocusAnimation(isFocused), [isFocused]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const animatedIconStyle = useAnimatedStyle(() => ({
     transform: [{ scale: interpolate(iconScale.value, [0, 1], [1, 1.2]) }],
@@ -70,32 +70,19 @@ const TabBarButton = ({
             color={isFocused ? 'primary' : 'neutral2'}
           />
         </Animated.View>
-        <LabelWrapper style={animatedTextStyle}>
-          <StyledLabel variant="bodyExtraSmall" isFocused={isFocused}>
+        <Animated.View style={animatedTextStyle}>
+          <Text
+            variant="bodyExtraSmall"
+            color={isFocused ? 'primary' : 'textMuted'}
+          >
             {label}
-          </StyledLabel>
-        </LabelWrapper>
+          </Text>
+        </Animated.View>
       </Stack>
     </Wrapper>
   );
-};
+}
 
 const Wrapper = styled(Pressable, {
   flex: 1,
 });
-
-const LabelWrapper = Animated.createAnimatedComponent(styled('View', {}));
-
-const StyledLabel = styled(Text, {
-  variants: {
-    isFocused: {
-      true: { color: '$primary' },
-      false: { color: '$textMuted' },
-    },
-  },
-});
-
-export const TabButton = memo(
-  TabBarButton,
-  (prev, next) => prev.isFocused === next.isFocused
-);

--- a/src/components/common/custom-bottom-bar/Tab.tsx
+++ b/src/components/common/custom-bottom-bar/Tab.tsx
@@ -1,0 +1,101 @@
+import { msg } from '@lingui/macro';
+import { memo, useMemo } from 'react';
+import { Pressable } from 'react-native';
+import Animated, {
+  interpolate,
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+  withTiming,
+} from 'react-native-reanimated';
+
+import { type TabList } from '~app/(tabs)/_layout';
+import { Icon, Stack, Text } from '~components/uikit';
+import { useI18n } from '~services/i18n';
+import { styled } from '~styles';
+
+const ANIMATION_DURATION = 350;
+
+type TabBarButtonProps = {
+  onPress: () => void;
+  onLongPress: () => void;
+  isFocused: boolean;
+  label: string;
+  tab: TabList[number];
+};
+
+const TabBarButton = ({
+  isFocused,
+  label,
+  tab,
+  ...pressableProps
+}: TabBarButtonProps) => {
+  const { _ } = useI18n();
+  const iconScale = useSharedValue(isFocused ? 1 : 0);
+  const labelOpacity = useSharedValue(isFocused ? 1 : 0);
+
+  const updateFocusAnimation = (focused: boolean) => {
+    iconScale.value = withSpring(focused ? 1 : 0, {
+      duration: ANIMATION_DURATION,
+    });
+    labelOpacity.value = withSpring(focused ? 1 : 0, {
+      duration: ANIMATION_DURATION,
+    });
+  };
+
+  useMemo(() => updateFocusAnimation(isFocused), [isFocused]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const animatedIconStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: interpolate(iconScale.value, [0, 1], [1, 1.2]) }],
+    top: interpolate(iconScale.value, [0, 1], [0, 8]),
+  }));
+
+  const animatedTextStyle = useAnimatedStyle(() => ({
+    opacity: interpolate(labelOpacity.value, [0, 1], [1, 0]),
+  }));
+
+  return (
+    <Wrapper
+      {...pressableProps}
+      onPressIn={() => (iconScale.value = withTiming(0.8, { duration: 150 }))}
+      onPressOut={() => (iconScale.value = withTiming(1, { duration: 150 }))}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      accessibilityHint={_(msg`Double tap to select this tab`)}
+    >
+      <Stack axis="y" align="center" spacing="xs">
+        <Animated.View style={animatedIconStyle}>
+          <Icon
+            name={isFocused ? tab.iconFilled : tab.iconOutlined}
+            color={isFocused ? 'primary' : 'neutral2'}
+          />
+        </Animated.View>
+        <LabelWrapper style={animatedTextStyle}>
+          <StyledLabel variant="bodyExtraSmall" isFocused={isFocused}>
+            {label}
+          </StyledLabel>
+        </LabelWrapper>
+      </Stack>
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled(Pressable, {
+  flex: 1,
+});
+
+const LabelWrapper = Animated.createAnimatedComponent(styled('View', {}));
+
+const StyledLabel = styled(Text, {
+  variants: {
+    isFocused: {
+      true: { color: '$primary' },
+      false: { color: '$textMuted' },
+    },
+  },
+});
+
+export const TabButton = memo(
+  TabBarButton,
+  (prev, next) => prev.isFocused === next.isFocused
+);


### PR DESCRIPTION
## ✨ What has changed?

- Introduced `CustomBottomBar` component for enhanced customization of bottom tabs (e.g., animations, unique styles)
- Added `USE_CUSTOM_TABS` flag to toggle between `CustomBottomBar` and `DefaultBottomBar`
- Included developer notes on when to use the custom bottom bar for client-specific needs
- Separated `(tabs)/_layout.tsx` for web and native and replaced `tabs` by `drawer` on web.


https://github.com/user-attachments/assets/58924d22-c937-4ed4-b296-4c3ef1fbb3b3

![Taito Template · 4 09pm · 11-27](https://github.com/user-attachments/assets/78850178-6ef0-4b19-8a67-e2e2e7a62011)

![Taito Template · 4 09pm · 11-27 (1)](https://github.com/user-attachments/assets/472d2641-aa09-4d27-8f18-f0aaa8382210)


