### PR TITLE
Feat/add sentry

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,11 @@ Follow this [CICD guide](/docs/CICD.md).
 ### Setup Sentry
 
 1. Create a project in [Sentry](https://sentry.io) (get credentials from Taito).
-2. In Sentry dashboard, go to project settings, click **Client Keys (DSN)** and copy the DSN to Sentry initialization configurations in `src/app/_layout.tsx`.
-3. Replace the project name in sentry config in `app.config.ts` with the project name you created in Sentry.
-4. To allow the Expo CI to upload source maps to sentry, you have to add a sentry auth token to expo. In Sentry dashboard General Settings (not project specific), go to **Auth Tokens** and **Create New Token**. Name it after your project. Copy it to create an environment variable in your **Expo** project: **Environment variables** > **Add variable** > Name: `SENTRY_AUTH_TOKEN`, paste the value, and set **Visibility** to **Secret**.
+2. In Sentry dashboard, go to project settings, click **Client Keys (DSN)** and create a DSN. This is the URL that your app will send error reports to. Create a file in your project root named `.env.local` and paste the DSN there: `EXPO_PUBLIC_SENTRY_DSN=<your_dsn>`
+3. Push the env into Expo by `eas env:push`. Select all environments.
+4. Replace the project name in Sentry config in `app.config.ts` with the project name you created in Sentry.
+
+> Context: Sentry needs source maps to make the stacktraces more readable. Expo CI will do this automatically after building the app, and for OTA-updates, our `npm run eas:update` will also do this for you after publishing the update.
 
 ### Setup a design system
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ Update the following fields in the `config/app.config.ts`:
 
 Follow this [CICD guide](/docs/CICD.md).
 
+### Setup Sentry
+
+1. Create a project in [Sentry](https://sentry.io) (get credentials from Taito).
+2. In Sentry dashboard, go to project settings, click **Client Keys (DSN)** and copy the DSN to Sentry initialization configurations in `src/app/_layout.tsx`.
+3. Replace the project name in sentry config in `app.config.ts` with the project name you created in Sentry.
+4. To allow the Expo CI to upload source maps to sentry, you have to add a sentry auth token to expo. In Sentry dashboard General Settings (not project specific), go to **Auth Tokens** and **Create New Token**. Name it after your project. Copy it to create an environment variable in your **Expo** project: **Environment variables** > **Add variable** > Name: `SENTRY_AUTH_TOKEN`, paste the value, and set **Visibility** to **Secret**.
+
 ### Setup a design system
 
 1. If you don't have a design system yet clone the [Design System Template](https://www.figma.com/file/vEO1Adp6j0nHiiq9BiexE1/Design-System-Template) project in Figma.

--- a/app.config.ts
+++ b/app.config.ts
@@ -107,8 +107,14 @@ const expoConfig: ExpoConfig = {
     [
       '@sentry/react-native/expo',
       {
+        /**
+         * _[CUSTOMIZE]_
+         *
+         * Create a project in sentry and customize these to match the project.
+         */
+
         organization: 'taito-united',
-        project: 'react-native', // TODO change this to your project name
+        project: 'react-native',
         url: 'https://sentry.io/',
       },
     ],

--- a/app.config.ts
+++ b/app.config.ts
@@ -104,6 +104,14 @@ const expoConfig: ExpoConfig = {
       'expo-build-properties',
       { android: { extraProguardRules: getExtraProguardRules() } },
     ],
+    [
+      '@sentry/react-native/expo',
+      {
+        organization: 'taito-united',
+        project: 'react-native', // TODO change this to your project name
+        url: 'https://sentry.io/',
+      },
+    ],
   ],
 };
 

--- a/docs/UPDATES.md
+++ b/docs/UPDATES.md
@@ -6,6 +6,6 @@ You can find the Expo documentation [here](https://docs.expo.dev/versions/latest
 
 ## Publishing an update
 
-We built a custom script to make it easier to publish updates. You can run the script `eas:update` to publish an update to the app.
+We built a custom script to make it easier to publish updates. You can run the script `eas:update` to publish an update to the app. It will also take care of uploading source maps to sentry.
 
 The script will ask you for which environment you want to publish the update to (e.g. **Testing** or **Production**) and for a description of the update (e.g. _"Fixing the login issue"_), which will be helpful to know what was changed in the update when looking at the EAS dashboard.

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,12 +1,12 @@
 // Learn more https://docs.expo.io/guides/customizing-metro
-const { getDefaultConfig } = require('expo/metro-config');
+const { getSentryExpoConfig } = require('@sentry/react-native/metro');
 
 // Learn more https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started#step-3-wrap-metro-config-with-reanimated-wrapper-recommended
 const {
   wrapWithReanimatedMetroConfig,
 } = require('react-native-reanimated/metro-config');
 
-const config = getDefaultConfig(__dirname);
+const config = getSentryExpoConfig(__dirname);
 
 config.transformer.minifierConfig = {
   compress: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@react-native-menu/menu": "1.1.6",
         "@react-navigation/drawer": "^7.0.0",
         "@react-navigation/native": "^7.0.0",
+        "@sentry/react-native": "~6.3.0",
         "@shopify/flash-list": "1.7.1",
         "expo": "~52.0.7",
         "expo-application": "~6.0.1",
@@ -5794,6 +5795,310 @@
         "join-component": "^1.1.0"
       }
     },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "8.40.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-8.40.0.tgz",
+      "integrity": "sha512-tx7gb/PWMbTEyil/XPETVeRUeS3nKHIvQY2omyebw30TbhyLnibPZsUmXJiaIysL5PcY3k9maub3W/o0Y37T7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "8.40.0",
+        "@sentry/types": "8.40.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "8.40.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-8.40.0.tgz",
+      "integrity": "sha512-1O9F3z80HNE0VfepKS+v+dixdatNqWlrlwgvvWl4BGzzoA+XhqvZo+HWxiOt7yx7+k1TuZNrB6Gy3u/QvpozXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "8.40.0",
+        "@sentry/types": "8.40.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "8.40.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-8.40.0.tgz",
+      "integrity": "sha512-0SaDsBCSWxNVgNmPKu23frrHEXzN/MKl0hIkfuO55vL5TgjLTwpgkf0Ne4rNvaZQ5omIKk9Qd63HuQP3PHAMaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "8.40.0",
+        "@sentry/core": "8.40.0",
+        "@sentry/types": "8.40.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "8.40.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-8.40.0.tgz",
+      "integrity": "sha512-Zr+m/le0SH4RowZB7rBCM0aRnvH3wZTaOFhwUk03/oGf2BRcgKuDCUMjnXKC9MyOpmey7UYXkzb8ro+81R6Q8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "8.40.0",
+        "@sentry/core": "8.40.0",
+        "@sentry/types": "8.40.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/babel-plugin-component-annotate": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-2.20.1.tgz",
+      "integrity": "sha512-4mhEwYTK00bIb5Y9UWIELVUfru587Vaeg0DQGswv4aIRHIiMKLyNqCEejaaybQ/fNChIZOKmvyqXk430YVd7Qg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "8.40.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-8.40.0.tgz",
+      "integrity": "sha512-m/Yor6IDBeDHtQochu8n6z4HXrXkrPhu6+o5Ouve0Zi3ptthSoK1FOGvJxVBat3nRq0ydQyuuPuTB6WfdWbwHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "8.40.0",
+        "@sentry-internal/feedback": "8.40.0",
+        "@sentry-internal/replay": "8.40.0",
+        "@sentry-internal/replay-canvas": "8.40.0",
+        "@sentry/core": "8.40.0",
+        "@sentry/types": "8.40.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/cli": {
+      "version": "2.38.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.38.2.tgz",
+      "integrity": "sha512-CR0oujpAnhegK2pBAv6ZReMqbFTuNJLDZLvoD1B+syrKZX+R+oxkgT2e1htsBbht+wGxAsluVWsIAydSws1GAA==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "sentry-cli": "bin/sentry-cli"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@sentry/cli-darwin": "2.38.2",
+        "@sentry/cli-linux-arm": "2.38.2",
+        "@sentry/cli-linux-arm64": "2.38.2",
+        "@sentry/cli-linux-i686": "2.38.2",
+        "@sentry/cli-linux-x64": "2.38.2",
+        "@sentry/cli-win32-i686": "2.38.2",
+        "@sentry/cli-win32-x64": "2.38.2"
+      }
+    },
+    "node_modules/@sentry/cli-darwin": {
+      "version": "2.38.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.38.2.tgz",
+      "integrity": "sha512-21ywIcJCCFrCTyiF1o1PaT7rbelFC2fWmayKYgFElnQ55IzNYkcn8BYhbh/QknE0l1NBRaeWMXwTTdeoqETCCg==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm": {
+      "version": "2.38.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.38.2.tgz",
+      "integrity": "sha512-+AiKDBQKIdQe4NhBiHSHGl0KR+b//HHTrnfK1SaTrOm9HtM4ELXAkjkRF3bmbpSzSQCS5WzcbIxxCJOeaUaO0A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm64": {
+      "version": "2.38.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.38.2.tgz",
+      "integrity": "sha512-4Fp/jjQpNZj4Th+ZckMQvldAuuP0ZcyJ9tJCP1CCOn5poIKPYtY6zcbTP036R7Te14PS4ALOcDNX3VNKfpsifA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-i686": {
+      "version": "2.38.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.38.2.tgz",
+      "integrity": "sha512-6zVJN10dHIn4R1v+fxuzlblzVBhIVwsaN/S7aBED6Vn1HhAyAcNG2tIzeCLGeDfieYjXlE2sCI82sZkQBCbAGw==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-x64": {
+      "version": "2.38.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.38.2.tgz",
+      "integrity": "sha512-4UiLu9zdVtqPeltELR5MDGKcuqAdQY9xz3emISuA6bm+MXGbt2W1WgX+XY3GElwjZbmH8qpyLUEd34sw6sdcbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-i686": {
+      "version": "2.38.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.38.2.tgz",
+      "integrity": "sha512-DYfSvd5qLPerLpIxj3Xu2rRe3CIlpGOOfGSNI6xvJ5D8j6hqbOHlCzvfC4oBWYVYGtxnwQLMeDGJ7o7RMYulig==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-x64": {
+      "version": "2.38.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.38.2.tgz",
+      "integrity": "sha512-W5UX58PKY1hNUHo9YJxWNhGvgvv2uOYHI27KchRiUvFYBIqlUUcIdPZDfyzetDfd8qBCxlAsFnkL2VJSNdpA9A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "8.40.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.40.0.tgz",
+      "integrity": "sha512-u/U2CJpG/+SmTR2bPM4ZZoPYTJAOUuxzj/0IURnvI0v9+rNu939J/fzrO9huA5IJVxS5TiYykhQm7o6I3Zuo3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "8.40.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "8.40.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-8.40.0.tgz",
+      "integrity": "sha512-Ohq/po83r9sh/DCO6VAxx4xU+1ztvFzmXTl3fUnAEc+2bFJK1MsRt6BWfG37XxjQN//mfmyS9KEBgsOpOyd4LQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "8.40.0",
+        "@sentry/core": "8.40.0",
+        "@sentry/types": "8.40.0",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@sentry/react-native": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-6.3.0.tgz",
+      "integrity": "sha512-gbLEiqxBjejxhrD4tUEACQoAPZTpCxsnuY16mGu5M889yvAEkJvDHwS/SApMlSYf8ytprnn/LPHPePhcVz/vYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/babel-plugin-component-annotate": "2.20.1",
+        "@sentry/browser": "8.40.0",
+        "@sentry/cli": "2.38.2",
+        "@sentry/core": "8.40.0",
+        "@sentry/react": "8.40.0",
+        "@sentry/types": "8.40.0",
+        "@sentry/utils": "8.40.0"
+      },
+      "bin": {
+        "sentry-expo-upload-sourcemaps": "scripts/expo-upload-sourcemaps.js"
+      },
+      "peerDependencies": {
+        "expo": ">=49.0.0",
+        "react": ">=17.0.0",
+        "react-native": ">=0.65.0"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/types": {
+      "version": "8.40.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.40.0.tgz",
+      "integrity": "sha512-nuCf3U3deolPM9BjNnwCc33UtFl9ec15/r74ngAkNccn+A2JXdIAsDkGJMO/9mgSFykLe1QyeJ0pQFRisCGOiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/utils": {
+      "version": "8.40.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.40.0.tgz",
+      "integrity": "sha512-JrfnrQ4irbXWTb+8QC5TCefr3KJJ1x4tJr5p+HyVy4df0n7SIvSqQNeG2P8uuT82F4puFsD6hkQYxuGr3y/NSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "8.40.0",
+        "@sentry/types": "8.40.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
     "node_modules/@shopify/flash-list": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@shopify/flash-list/-/flash-list-1.7.1.tgz",
@@ -6404,7 +6709,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "dependencies": {
         "debug": "4"
       },
@@ -11334,7 +11638,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -15567,6 +15870,12 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/pseudolocale": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
     "react-native-web": "~0.19.13",
     "stitches-native": "0.4.0",
     "zeego": "2.0.4",
-    "zustand": "5.0.1"
+    "zustand": "5.0.1",
+    "@sentry/react-native": "~6.3.0"
   },
   "devDependencies": {
     "@babel/core": "7.26.0",

--- a/scripts/update.mjs
+++ b/scripts/update.mjs
@@ -1,8 +1,7 @@
+/* eslint-disable lingui/no-unlocalized-strings */
 import { spawnSync } from 'child_process';
 import inquirer from 'inquirer';
 import ora from 'ora';
-import fs from 'fs';
-import path from 'path';
 
 async function main() {
   const spinner = ora('Processing...');
@@ -23,9 +22,16 @@ async function main() {
     runPreBuildTasks(answers.profile);
 
     const command = constructEASCommand(branchName, answers.message);
-    console.info('> Command: ', command);
 
+    console.info('> Command: ', command);
     runCommandSync(command, `> EAS update finished for branch: ${branchName}`);
+
+    console.info('> Uploading source maps to sentry...');
+    runCommandSync(
+      `eas env:exec production 'npx sentry-expo-upload-sourcemaps dist'`,
+      `> Source maps uploaded to sentry.`
+    );
+
     spinner.succeed('Operation completed successfully.');
   } catch (error) {
     console.error('> Error:', error.message);

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -25,7 +25,13 @@ const navigationIntegration = Sentry.reactNavigationIntegration({
 });
 
 Sentry.init({
-  dsn: process.env.SENTRY_DSN,
+  /**
+   * _[CUSTOMIZE]_
+   * Replace DSN with the one from Sentry project settings.
+   * Adjust tracesSampleRate and enableNativeFramesTracking if performance tracing is necessary.
+   */
+
+  dsn: '',
   tracesSampleRate: 0.0,
   enableNativeFramesTracking: false,
   integrations: [navigationIntegration],

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -1,8 +1,16 @@
 import { registerDevMenuItems } from 'expo-dev-menu';
-import { Stack, router, usePathname, useSegments } from 'expo-router';
+import {
+  Stack,
+  router,
+  useNavigationContainerRef,
+  usePathname,
+  useSegments,
+} from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
+import * as Sentry from '@sentry/react-native';
 import { useEffect } from 'react';
 import { DevSettings, Platform } from 'react-native';
+import { isRunningInExpoGo } from 'expo';
 
 import Providers from '~Providers';
 import StatusBar from '~components/common/StatusBar';
@@ -11,6 +19,17 @@ import { useAuthStore } from '~services/auth';
 import { useEffectEvent } from '~utils/common';
 import { useAppReady } from '~utils/init';
 import { useDefaultStackScreenOptions } from '~utils/navigation';
+
+const navigationIntegration = Sentry.reactNavigationIntegration({
+  enableTimeToInitialDisplay: !isRunningInExpoGo(),
+});
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  tracesSampleRate: 0.0,
+  enableNativeFramesTracking: false,
+  integrations: [navigationIntegration],
+});
 
 if (__DEV__ && ['android', 'ios'].includes(Platform.OS)) {
   const devMenuItems = [
@@ -32,8 +51,16 @@ if (__DEV__ && ['android', 'ios'].includes(Platform.OS)) {
 
 SplashScreen.preventAutoHideAsync();
 
-export default function RootLayout() {
+const RootLayout = () => {
   const appReady = useAppReady();
+
+  const ref = useNavigationContainerRef();
+
+  useEffect(() => {
+    if (ref?.current) {
+      navigationIntegration.registerNavigationContainer(ref);
+    }
+  }, [ref]);
 
   if (!appReady) return null;
 
@@ -45,7 +72,7 @@ export default function RootLayout() {
       {appReady && <RouteProtection />}
     </Providers>
   );
-}
+};
 
 function RootLayoutNavigator() {
   const screenOptions = useDefaultStackScreenOptions();
@@ -61,6 +88,8 @@ function RootLayoutNavigator() {
     </Stack>
   );
 }
+
+export default Sentry.wrap(RootLayout);
 
 // We are guaranteed to be either in `unauthenticated` or `authenticated` state
 // at this point so we don't need to care about the other auth states

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -25,13 +25,7 @@ const navigationIntegration = Sentry.reactNavigationIntegration({
 });
 
 Sentry.init({
-  /**
-   * _[CUSTOMIZE]_
-   * Replace DSN with the one from Sentry project settings.
-   * Adjust tracesSampleRate and enableNativeFramesTracking if performance tracing is necessary.
-   */
-
-  dsn: '',
+  dsn: process.env.EXPO_PUBLIC_SENTRY_DSN,
   tracesSampleRate: 0.0,
   enableNativeFramesTracking: false,
   integrations: [navigationIntegration],

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -13,11 +13,11 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/uikit/inputs/TextInput.tsx:165
+#: src/components/uikit/inputs/TextInput.tsx:167
 msgid "{label} input field"
 msgstr "{label} input field"
 
-#: src/app/(tabs)/_layout.tsx:114
+#: src/app/(tabs)/_layout.tsx:159
 msgid "{title} tab"
 msgstr "{title} tab"
 
@@ -29,11 +29,11 @@ msgstr "Allows you to pick an option from the list"
 msgid "An error occurred while requesting review"
 msgstr "An error occurred while requesting review"
 
-#: src/components/settings/SystemInfoMenuTarget.tsx:45
+#: src/components/settings/SystemInfoMenuTarget.tsx:46
 msgid "API level"
 msgstr "API level"
 
-#: src/components/settings/SystemInfoMenuTarget.tsx:56
+#: src/components/settings/SystemInfoMenuTarget.tsx:57
 msgid "App environment"
 msgstr "App environment"
 
@@ -41,7 +41,7 @@ msgstr "App environment"
 msgid "Appearance"
 msgstr "Appearance"
 
-#: src/app/(tabs)/settings.tsx:26
+#: src/app/(tabs)/settings.tsx:29
 msgid "Are you sure you want to logout?"
 msgstr ""
 
@@ -54,7 +54,7 @@ msgstr "Automatic"
 msgid "Back"
 msgstr ""
 
-#: src/components/settings/SystemInfoMenuTarget.tsx:90
+#: src/components/settings/SystemInfoMenuTarget.tsx:92
 msgid "Bundle ID"
 msgstr "Bundle ID"
 
@@ -63,8 +63,8 @@ msgstr "Bundle ID"
 msgid "By Taito United"
 msgstr "By Taito United"
 
-#: src/app/(tabs)/settings.tsx:27
-#: src/components/uikit/inputs/DateInput.tsx:99
+#: src/app/(tabs)/settings.tsx:30
+#: src/components/uikit/inputs/DateInput.tsx:101
 #: src/components/uikit/PickerModal.tsx:220
 #: src/components/uikit/PickerSheet.tsx:162
 msgid "Cancel"
@@ -74,15 +74,15 @@ msgstr ""
 msgid "Cannot open {type}"
 msgstr ""
 
-#: src/components/uikit/inputs/TextInput.tsx:127
+#: src/components/uikit/inputs/TextInput.tsx:129
 msgid "Character count"
 msgstr "Character count"
 
-#: src/components/uikit/inputs/Checkbox.tsx:43
+#: src/components/uikit/inputs/Checkbox.tsx:49
 msgid "Checkbox option: {label}"
 msgstr "Checkbox option: {label}"
 
-#: src/components/uikit/inputs/TextInput.tsx:196
+#: src/components/uikit/inputs/TextInput.tsx:198
 msgid "Clear input"
 msgstr "Clear input"
 
@@ -113,7 +113,7 @@ msgstr "Close the picker without selecting any option"
 msgid "Closing the picker modal with selected option {value}"
 msgstr "Closing the picker modal with selected option {value}"
 
-#: src/components/uikit/inputs/DateInput.tsx:98
+#: src/components/uikit/inputs/DateInput.tsx:100
 msgid "Confirm"
 msgstr "Confirm"
 
@@ -125,8 +125,8 @@ msgstr "Confirm selected options and close the picker"
 msgid "Confirming selected options will close the picker"
 msgstr "Confirming selected options will close the picker"
 
-#: src/app/playground/icons.tsx:28
-#: src/components/settings/SystemInfoMenuTarget.tsx:73
+#: src/app/playground/icons.tsx:30
+#: src/components/settings/SystemInfoMenuTarget.tsx:75
 msgid "Copied to clipboard"
 msgstr "Copied to clipboard"
 
@@ -144,7 +144,7 @@ msgstr ""
 
 #: src/app/(auth)/landing.tsx:80
 #: src/app/(auth)/landing.web.tsx:73
-#: src/app/(auth)/signup.tsx:56
+#: src/app/(auth)/signup.tsx:58
 msgid "Create an account"
 msgstr "Create an account"
 
@@ -153,15 +153,15 @@ msgstr "Create an account"
 msgid "Dark"
 msgstr "Dark"
 
-#: src/components/uikit/inputs/DateInput.tsx:85
+#: src/components/uikit/inputs/DateInput.tsx:87
 msgid "Date picker input for {label}, current value: {value}"
 msgstr "Date picker input for {label}, current value: {value}"
 
-#: src/components/settings/SystemInfoMenuTarget.tsx:28
+#: src/components/settings/SystemInfoMenuTarget.tsx:29
 msgid "Device ID"
 msgstr "Device ID"
 
-#: src/app/(auth)/signup.tsx:59
+#: src/app/(auth)/signup.tsx:61
 msgid "Don‘t worry, these won‘t actually be saved."
 msgstr "Don‘t worry, these won‘t actually be saved."
 
@@ -170,7 +170,7 @@ msgstr "Don‘t worry, these won‘t actually be saved."
 msgid "Done"
 msgstr ""
 
-#: src/components/uikit/inputs/Checkbox.tsx:47
+#: src/components/uikit/inputs/Checkbox.tsx:53
 msgid "Double tap to check this option"
 msgstr "Double tap to check this option"
 
@@ -178,15 +178,15 @@ msgstr "Double tap to check this option"
 msgid "Double tap to clear selected options"
 msgstr "Double tap to clear selected options"
 
-#: src/components/uikit/inputs/TextInput.tsx:197
+#: src/components/uikit/inputs/TextInput.tsx:199
 msgid "Double tap to clear the input"
 msgstr "Double tap to clear the input"
 
-#: src/components/uikit/Accordion.tsx:42
+#: src/components/uikit/Accordion.tsx:48
 msgid "Double tap to collapse the content"
 msgstr "Double tap to collapse the content"
 
-#: src/components/uikit/inputs/TextInput.tsx:106
+#: src/components/uikit/inputs/TextInput.tsx:108
 msgid "Double tap to edit {label}"
 msgstr "Double tap to edit {label}"
 
@@ -194,35 +194,35 @@ msgstr "Double tap to edit {label}"
 msgid "Double tap to enter a value"
 msgstr "Double tap to enter a value"
 
-#: src/components/uikit/Accordion.tsx:41
+#: src/components/uikit/Accordion.tsx:47
 msgid "Double tap to expand the content"
 msgstr "Double tap to expand the content"
 
-#: src/app/(auth)/login.tsx:117
+#: src/app/(auth)/login.tsx:119
 msgid "Double tap to log in with the provided email and password"
 msgstr "Double tap to log in with the provided email and password"
 
-#: src/components/uikit/inputs/DateInput.tsx:86
+#: src/components/uikit/inputs/DateInput.tsx:88
 msgid "Double tap to open date picker"
 msgstr "Double tap to open date picker"
 
-#: src/components/uikit/inputs/Select.tsx:123
+#: src/components/uikit/inputs/Select.tsx:125
 msgid "Double tap to open options to select"
 msgstr "Double tap to open options to select"
 
-#: src/components/uikit/buttons/IconButton.tsx:88
+#: src/components/uikit/buttons/IconButton.tsx:96
 msgid "Double tap to perform action"
 msgstr "Double tap to perform action"
 
-#: src/components/common/MenuList.tsx:68
+#: src/components/common/MenuList.tsx:70
 msgid "Double tap to select {0}"
 msgstr "Double tap to select {0}"
 
-#: src/components/uikit/inputs/Radio.tsx:27
+#: src/components/uikit/inputs/Radio.tsx:34
 msgid "Double tap to select this option"
 msgstr "Double tap to select this option"
 
-#: src/components/uikit/SegmentedControl.tsx:118
+#: src/components/uikit/SegmentedControl.tsx:120
 msgid "Double tap to select this segment"
 msgstr "Double tap to select this segment"
 
@@ -230,26 +230,30 @@ msgstr "Double tap to select this segment"
 msgid "Double tap to select this suggestion"
 msgstr "Double tap to select this suggestion"
 
-#: src/app/(auth)/signup.tsx:236
+#: src/components/common/custom-bottom-bar/Tab.tsx:64
+msgid "Double tap to select this tab"
+msgstr "Double tap to select this tab"
+
+#: src/app/(auth)/signup.tsx:238
 msgid "Double tap to signup with the provided information"
 msgstr "Double tap to signup with the provided information"
 
-#: src/components/uikit/inputs/Checkbox.tsx:48
+#: src/components/uikit/inputs/Checkbox.tsx:54
 msgid "Double tap to uncheck this option"
 msgstr "Double tap to uncheck this option"
 
-#: src/app/(auth)/login.tsx:72
-#: src/app/(auth)/signup.tsx:86
+#: src/app/(auth)/login.tsx:74
+#: src/app/(auth)/signup.tsx:88
 msgid "Email"
-msgstr ""
-
-#: src/app/(auth)/login.tsx:64
-#: src/app/(auth)/signup.tsx:78
-msgid "Email invalid"
 msgstr ""
 
 #: src/app/(auth)/login.tsx:66
 #: src/app/(auth)/signup.tsx:80
+msgid "Email invalid"
+msgstr ""
+
+#: src/app/(auth)/login.tsx:68
+#: src/app/(auth)/signup.tsx:82
 msgid "Email required"
 msgstr ""
 
@@ -264,19 +268,19 @@ msgstr "English"
 msgid "Enjoying the app?"
 msgstr "Enjoying the app?"
 
-#: src/components/uikit/inputs/TextInput.tsx:166
+#: src/components/uikit/inputs/TextInput.tsx:168
 msgid "Enter your {label} here"
 msgstr "Enter your {label} here"
 
-#: src/app/(auth)/login.tsx:40
+#: src/app/(auth)/login.tsx:42
 msgid "Enter your credentials"
 msgstr "Enter your credentials"
 
-#: src/app/(auth)/login.tsx:30
+#: src/app/(auth)/login.tsx:32
 msgid "Failed to login"
 msgstr ""
 
-#: src/app/(auth)/signup.tsx:46
+#: src/app/(auth)/signup.tsx:48
 msgid "Failed to signup"
 msgstr ""
 
@@ -288,7 +292,7 @@ msgstr "Feedback is required"
 msgid "Feedback sent!"
 msgstr "Feedback sent!"
 
-#: src/components/settings/SystemInfoMenuTarget.tsx:30
+#: src/components/settings/SystemInfoMenuTarget.tsx:31
 msgid "Fetching..."
 msgstr "Fetching..."
 
@@ -298,20 +302,21 @@ msgstr "Fetching..."
 msgid "Finnish"
 msgstr "Finnish"
 
-#: src/app/(auth)/signup.tsx:108
+#: src/app/(auth)/signup.tsx:110
 msgid "First name"
 msgstr ""
 
-#: src/app/(auth)/signup.tsx:103
+#: src/app/(auth)/signup.tsx:105
 msgid "First name is required"
 msgstr ""
 
-#: src/components/uikit/inputs/TextInput.tsx:179
+#: src/components/uikit/inputs/TextInput.tsx:181
 msgid "Hide text by toggling visibility"
 msgstr "Hide text by toggling visibility"
 
-#: src/app/(tabs)/_layout.tsx:27
-#: src/app/(tabs)/home.tsx:20
+#: src/app/(tabs)/_layout.tsx:52
+#: src/app/(tabs)/_layout.web.tsx:20
+#: src/app/(tabs)/home.tsx:10
 msgid "Home"
 msgstr ""
 
@@ -319,11 +324,11 @@ msgstr ""
 msgid "How can we improve?"
 msgstr "How can we improve?"
 
-#: src/app/(tabs)/settings.tsx:28
+#: src/app/(tabs)/settings.tsx:31
 msgid "I am sure"
 msgstr "I am sure"
 
-#: src/components/uikit/buttons/IconButton.tsx:87
+#: src/components/uikit/buttons/IconButton.tsx:95
 msgid "Icon button with {icon} icon"
 msgstr "Icon button with {icon} icon"
 
@@ -331,15 +336,15 @@ msgstr "Icon button with {icon} icon"
 msgid "Info"
 msgstr "Info"
 
-#: src/components/uikit/inputs/TextInput.tsx:210
+#: src/components/uikit/inputs/TextInput.tsx:212
 msgid "Informational message for the {label} input field"
 msgstr "Informational message for the {label} input field"
 
-#: src/components/common/MenuList.tsx:66
+#: src/components/common/MenuList.tsx:68
 msgid "Item"
 msgstr "Item"
 
-#: src/components/uikit/inputs/TextInput.tsx:105
+#: src/components/uikit/inputs/TextInput.tsx:107
 msgid "Label for {label} input"
 msgstr "Label for {label} input"
 
@@ -355,11 +360,11 @@ msgstr "Language set to English"
 msgid "Language set to Finnish"
 msgstr "Language set to Finnish"
 
-#: src/app/(auth)/signup.tsx:127
+#: src/app/(auth)/signup.tsx:129
 msgid "Last name"
 msgstr ""
 
-#: src/app/(auth)/signup.tsx:122
+#: src/app/(auth)/signup.tsx:124
 msgid "Last name is required"
 msgstr ""
 
@@ -368,20 +373,20 @@ msgstr ""
 msgid "Light"
 msgstr "Light"
 
-#: src/app/(auth)/login.tsx:26
+#: src/app/(auth)/login.tsx:27
 msgid "Logged in successfully, entering the app"
 msgstr "Logged in successfully, entering the app"
 
-#: src/app/(tabs)/settings.tsx:21
+#: src/app/(tabs)/settings.tsx:23
 msgid "Logged out successfully, back to the landing page"
 msgstr "Logged out successfully, back to the landing page"
 
 #: src/app/(auth)/_layout.tsx:14
-#: src/app/(auth)/login.tsx:119
+#: src/app/(auth)/login.tsx:121
 msgid "Login"
 msgstr ""
 
-#: src/app/(tabs)/settings.tsx:39
+#: src/app/(tabs)/settings.tsx:42
 msgid "Logout"
 msgstr ""
 
@@ -389,7 +394,7 @@ msgstr ""
 msgid "Loving it"
 msgstr "Loving it"
 
-#: src/components/settings/SystemInfoMenuTarget.tsx:35
+#: src/components/settings/SystemInfoMenuTarget.tsx:36
 msgid "Model name"
 msgstr "Model name"
 
@@ -405,7 +410,7 @@ msgstr "Navigates to the sign-up screen"
 msgid "No results found."
 msgstr ""
 
-#: src/components/uikit/inputs/TextInput.tsx:129
+#: src/components/uikit/inputs/TextInput.tsx:131
 msgid "Number of characters entered in the input field: currently {characterCount} out of {maxLength}"
 msgstr "Number of characters entered in the input field: currently {characterCount} out of {maxLength}"
 
@@ -423,27 +428,27 @@ msgstr ""
 msgid "Or"
 msgstr "Or"
 
-#: src/app/(auth)/login.tsx:95
-#: src/app/(auth)/signup.tsx:178
+#: src/app/(auth)/login.tsx:97
+#: src/app/(auth)/signup.tsx:180
 msgid "Password"
 msgstr ""
 
-#: src/app/(auth)/signup.tsx:214
+#: src/app/(auth)/signup.tsx:216
 msgid "Password again"
 msgstr ""
 
-#: src/app/(auth)/login.tsx:90
-#: src/app/(auth)/signup.tsx:172
-#: src/app/(auth)/signup.tsx:208
+#: src/app/(auth)/login.tsx:92
+#: src/app/(auth)/signup.tsx:174
+#: src/app/(auth)/signup.tsx:210
 msgid "Password is required"
 msgstr ""
 
-#: src/app/(auth)/signup.tsx:170
-#: src/app/(auth)/signup.tsx:206
+#: src/app/(auth)/signup.tsx:172
+#: src/app/(auth)/signup.tsx:208
 msgid "Password must be at least 8 characters"
 msgstr ""
 
-#: src/app/(auth)/signup.tsx:204
+#: src/app/(auth)/signup.tsx:206
 msgid "Passwords do not match"
 msgstr ""
 
@@ -451,11 +456,11 @@ msgstr ""
 msgid "phone app"
 msgstr ""
 
-#: src/app/(auth)/signup.tsx:150
+#: src/app/(auth)/signup.tsx:152
 msgid "Phone number"
 msgstr ""
 
-#: src/app/(auth)/signup.tsx:141
+#: src/app/(auth)/signup.tsx:143
 msgid "Phone number is required"
 msgstr ""
 
@@ -467,24 +472,26 @@ msgstr "Picker Modal"
 msgid "Please try restarting the application."
 msgstr ""
 
-#: src/app/(auth)/signup.tsx:145
+#: src/app/(auth)/signup.tsx:147
 msgid "Preferred format: +358400123456"
 msgstr ""
 
-#: src/app/(tabs)/_layout.tsx:40
+#: src/app/(tabs)/_layout.tsx:65
+#: src/app/(tabs)/_layout.web.tsx:33
 #: src/app/(tabs)/profile.tsx:10
 msgid "Profile"
 msgstr ""
 
-#: src/components/uikit/inputs/Radio.tsx:26
+#: src/components/uikit/inputs/Radio.tsx:33
 msgid "Radio option: {label}"
 msgstr "Radio option: {label}"
 
-#: src/components/uikit/inputs/TextInput.tsx:114
+#: src/components/uikit/inputs/TextInput.tsx:116
 msgid "Required field indicator"
 msgstr "Required field indicator"
 
-#: src/app/(tabs)/_layout.tsx:33
+#: src/app/(tabs)/_layout.tsx:58
+#: src/app/(tabs)/_layout.web.tsx:26
 #: src/app/(tabs)/search.tsx:10
 #: src/components/uikit/inputs/SearchInput.tsx:28
 msgid "Search"
@@ -498,27 +505,28 @@ msgstr "Search input"
 msgid "Search options"
 msgstr "Search options"
 
-#: src/components/uikit/SegmentedControl.tsx:117
+#: src/components/uikit/SegmentedControl.tsx:119
 msgid "Segment {label}"
 msgstr "Segment {label}"
 
-#: src/components/uikit/inputs/Select.tsx:62
+#: src/components/uikit/inputs/Select.tsx:63
 msgid "Select"
 msgstr "Select"
 
-#: src/components/uikit/inputs/Select.tsx:122
+#: src/components/uikit/inputs/Select.tsx:124
 msgid "Select input for {label}, current value: {value}"
 msgstr "Select input for {label}, current value: {value}"
 
-#: src/components/common/MenuList.tsx:66
+#: src/components/common/MenuList.tsx:68
 msgid "Selected value"
 msgstr "Selected value"
 
-#: src/app/(tabs)/_layout.tsx:47
+#: src/app/(tabs)/_layout.tsx:72
+#: src/app/(tabs)/_layout.web.tsx:40
 msgid "Settings"
 msgstr ""
 
-#: src/components/uikit/inputs/TextInput.tsx:180
+#: src/components/uikit/inputs/TextInput.tsx:182
 msgid "Show text by toggling visibility"
 msgstr "Show text by toggling visibility"
 
@@ -527,12 +535,12 @@ msgstr "Show text by toggling visibility"
 msgid "Sign in"
 msgstr "Sign in"
 
-#: src/app/(auth)/signup.tsx:42
+#: src/app/(auth)/signup.tsx:43
 msgid "Signed up successfully, entering the app"
 msgstr "Signed up successfully, entering the app"
 
 #: src/app/(auth)/_layout.tsx:15
-#: src/app/(auth)/signup.tsx:238
+#: src/app/(auth)/signup.tsx:240
 msgid "Signup"
 msgstr ""
 
@@ -559,7 +567,7 @@ msgstr "Submit feedback"
 msgid "Suomi"
 msgstr "Suomi"
 
-#: src/components/settings/SystemInfoMenuTarget.tsx:40
+#: src/components/settings/SystemInfoMenuTarget.tsx:41
 msgid "System version"
 msgstr "System version"
 
@@ -572,15 +580,15 @@ msgstr "Taito Template"
 msgid "Thank you"
 msgstr "Thank you"
 
-#: src/components/uikit/inputs/TextInput.tsx:115
+#: src/components/uikit/inputs/TextInput.tsx:117
 msgid "This field is marked as required"
 msgstr "This field is marked as required"
 
-#: src/components/uikit/inputs/TextInput.tsx:211
+#: src/components/uikit/inputs/TextInput.tsx:213
 msgid "This is an error message for the {label} input field"
 msgstr "This is an error message for the {label} input field"
 
-#: src/components/uikit/inputs/TextInput.tsx:176
+#: src/components/uikit/inputs/TextInput.tsx:178
 msgid "Toggle visibility"
 msgstr "Toggle visibility"
 
@@ -588,7 +596,7 @@ msgstr "Toggle visibility"
 msgid "Try changing your search term."
 msgstr ""
 
-#: src/components/uikit/inputs/TextInput.tsx:39
+#: src/components/uikit/inputs/TextInput.tsx:40
 msgid "Type here"
 msgstr "Type here"
 
@@ -604,15 +612,15 @@ msgstr "Type to search and select from suggestions"
 msgid "Unable to change permission"
 msgstr ""
 
-#: src/components/settings/SystemInfoMenuTarget.tsx:31
+#: src/components/settings/SystemInfoMenuTarget.tsx:32
 msgid "Unavailable"
 msgstr "Unavailable"
 
-#: src/components/settings/SystemInfoMenuTarget.tsx:66
+#: src/components/settings/SystemInfoMenuTarget.tsx:67
 msgid "Update ID"
 msgstr "Update ID"
 
-#: src/components/settings/SystemInfoMenuTarget.tsx:51
+#: src/components/settings/SystemInfoMenuTarget.tsx:52
 msgid "Version"
 msgstr "Version"
 
@@ -621,7 +629,7 @@ msgstr "Version"
 msgid "Welcome to"
 msgstr "Welcome to"
 
-#: src/app/(auth)/login.tsx:47
+#: src/app/(auth)/login.tsx:49
 msgid "You can enter any email and password to login."
 msgstr "You can enter any email and password to login."
 

--- a/src/locales/fi/messages.po
+++ b/src/locales/fi/messages.po
@@ -13,11 +13,11 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/uikit/inputs/TextInput.tsx:165
+#: src/components/uikit/inputs/TextInput.tsx:167
 msgid "{label} input field"
 msgstr ""
 
-#: src/app/(tabs)/_layout.tsx:114
+#: src/app/(tabs)/_layout.tsx:159
 msgid "{title} tab"
 msgstr ""
 
@@ -29,11 +29,11 @@ msgstr ""
 msgid "An error occurred while requesting review"
 msgstr "Arvostelun pyytämisessä tapahtui virhe"
 
-#: src/components/settings/SystemInfoMenuTarget.tsx:45
+#: src/components/settings/SystemInfoMenuTarget.tsx:46
 msgid "API level"
 msgstr "API-taso"
 
-#: src/components/settings/SystemInfoMenuTarget.tsx:56
+#: src/components/settings/SystemInfoMenuTarget.tsx:57
 msgid "App environment"
 msgstr "Sovellusympäristö"
 
@@ -41,7 +41,7 @@ msgstr "Sovellusympäristö"
 msgid "Appearance"
 msgstr "Väriteema"
 
-#: src/app/(tabs)/settings.tsx:26
+#: src/app/(tabs)/settings.tsx:29
 msgid "Are you sure you want to logout?"
 msgstr "Oletko varma, että haluat kirjautua ulos?"
 
@@ -54,7 +54,7 @@ msgstr "Automaattinen"
 msgid "Back"
 msgstr "Takaisin"
 
-#: src/components/settings/SystemInfoMenuTarget.tsx:90
+#: src/components/settings/SystemInfoMenuTarget.tsx:92
 msgid "Bundle ID"
 msgstr "Pakettitunnus"
 
@@ -63,8 +63,8 @@ msgstr "Pakettitunnus"
 msgid "By Taito United"
 msgstr "Taito Unitedilta"
 
-#: src/app/(tabs)/settings.tsx:27
-#: src/components/uikit/inputs/DateInput.tsx:99
+#: src/app/(tabs)/settings.tsx:30
+#: src/components/uikit/inputs/DateInput.tsx:101
 #: src/components/uikit/PickerModal.tsx:220
 #: src/components/uikit/PickerSheet.tsx:162
 msgid "Cancel"
@@ -74,15 +74,15 @@ msgstr "Peruuta"
 msgid "Cannot open {type}"
 msgstr "Ei voida avata {type}"
 
-#: src/components/uikit/inputs/TextInput.tsx:127
+#: src/components/uikit/inputs/TextInput.tsx:129
 msgid "Character count"
 msgstr "Merkkimäärä"
 
-#: src/components/uikit/inputs/Checkbox.tsx:43
+#: src/components/uikit/inputs/Checkbox.tsx:49
 msgid "Checkbox option: {label}"
 msgstr "Valintaruudun vaihtoehto: {label}"
 
-#: src/components/uikit/inputs/TextInput.tsx:196
+#: src/components/uikit/inputs/TextInput.tsx:198
 msgid "Clear input"
 msgstr "Tyhjennä syöte"
 
@@ -113,7 +113,7 @@ msgstr "Sulje valitsin ilman valintaa"
 msgid "Closing the picker modal with selected option {value}"
 msgstr "Suljetaan valitsinikkuna valitulla vaihtoehdolla {value}"
 
-#: src/components/uikit/inputs/DateInput.tsx:98
+#: src/components/uikit/inputs/DateInput.tsx:100
 msgid "Confirm"
 msgstr "Vahvista"
 
@@ -125,8 +125,8 @@ msgstr "Vahvista valitut vaihtoehdot ja sulje valitsin"
 msgid "Confirming selected options will close the picker"
 msgstr ""
 
-#: src/app/playground/icons.tsx:28
-#: src/components/settings/SystemInfoMenuTarget.tsx:73
+#: src/app/playground/icons.tsx:30
+#: src/components/settings/SystemInfoMenuTarget.tsx:75
 msgid "Copied to clipboard"
 msgstr "Kopioitu leikepöydälle"
 
@@ -144,7 +144,7 @@ msgstr "Ei voitu muuttaa lupaa. Voit muuttaa lupaa järjestelmäasetuksista."
 
 #: src/app/(auth)/landing.tsx:80
 #: src/app/(auth)/landing.web.tsx:73
-#: src/app/(auth)/signup.tsx:56
+#: src/app/(auth)/signup.tsx:58
 msgid "Create an account"
 msgstr "Luo uusi tili"
 
@@ -153,15 +153,15 @@ msgstr "Luo uusi tili"
 msgid "Dark"
 msgstr "Tumma"
 
-#: src/components/uikit/inputs/DateInput.tsx:85
+#: src/components/uikit/inputs/DateInput.tsx:87
 msgid "Date picker input for {label}, current value: {value}"
 msgstr "Päivämäärän valitsin {label}, nykyinen arvo: {value}"
 
-#: src/components/settings/SystemInfoMenuTarget.tsx:28
+#: src/components/settings/SystemInfoMenuTarget.tsx:29
 msgid "Device ID"
 msgstr "Laitetunnus"
 
-#: src/app/(auth)/signup.tsx:59
+#: src/app/(auth)/signup.tsx:61
 msgid "Don‘t worry, these won‘t actually be saved."
 msgstr "Älä huoli, mitään ei oikeasti tallenneta"
 
@@ -170,7 +170,7 @@ msgstr "Älä huoli, mitään ei oikeasti tallenneta"
 msgid "Done"
 msgstr "Valmis"
 
-#: src/components/uikit/inputs/Checkbox.tsx:47
+#: src/components/uikit/inputs/Checkbox.tsx:53
 msgid "Double tap to check this option"
 msgstr "Tuplaklikkaa valitaksesi tämä vaihtoehto"
 
@@ -178,15 +178,15 @@ msgstr "Tuplaklikkaa valitaksesi tämä vaihtoehto"
 msgid "Double tap to clear selected options"
 msgstr "Tuplaklikkaa tyhjentääksesi valitut vaihtoehdot"
 
-#: src/components/uikit/inputs/TextInput.tsx:197
+#: src/components/uikit/inputs/TextInput.tsx:199
 msgid "Double tap to clear the input"
 msgstr "Tuplaklikkaa tyhjentääksesi syötteen"
 
-#: src/components/uikit/Accordion.tsx:42
+#: src/components/uikit/Accordion.tsx:48
 msgid "Double tap to collapse the content"
 msgstr "Tuplaklikkaa sulkeaksesi sisällön"
 
-#: src/components/uikit/inputs/TextInput.tsx:106
+#: src/components/uikit/inputs/TextInput.tsx:108
 msgid "Double tap to edit {label}"
 msgstr ""
 
@@ -194,35 +194,35 @@ msgstr ""
 msgid "Double tap to enter a value"
 msgstr "Tuplaklikkaa syöttääksesi arvon"
 
-#: src/components/uikit/Accordion.tsx:41
+#: src/components/uikit/Accordion.tsx:47
 msgid "Double tap to expand the content"
 msgstr "Tuplaklikkaa laajentaaksesi sisällön"
 
-#: src/app/(auth)/login.tsx:117
+#: src/app/(auth)/login.tsx:119
 msgid "Double tap to log in with the provided email and password"
 msgstr "Tuplaklikkaa kirjautuaksesi sähköpostilla ja salasanalla"
 
-#: src/components/uikit/inputs/DateInput.tsx:86
+#: src/components/uikit/inputs/DateInput.tsx:88
 msgid "Double tap to open date picker"
 msgstr "Tuplaklikkaa avataksesi päivämäärän valitsimen"
 
-#: src/components/uikit/inputs/Select.tsx:123
+#: src/components/uikit/inputs/Select.tsx:125
 msgid "Double tap to open options to select"
 msgstr "Tuplaklikkaa avataksesi valintavaihtoehdot"
 
-#: src/components/uikit/buttons/IconButton.tsx:88
+#: src/components/uikit/buttons/IconButton.tsx:96
 msgid "Double tap to perform action"
 msgstr "Tuplaklikkaa suorittaaksesi toiminnon"
 
-#: src/components/common/MenuList.tsx:68
+#: src/components/common/MenuList.tsx:70
 msgid "Double tap to select {0}"
 msgstr "Tuplaklikkaa valitaksesi {0}"
 
-#: src/components/uikit/inputs/Radio.tsx:27
+#: src/components/uikit/inputs/Radio.tsx:34
 msgid "Double tap to select this option"
 msgstr "Tuplaklikkaa valitaksesi tämä vaihtoehto"
 
-#: src/components/uikit/SegmentedControl.tsx:118
+#: src/components/uikit/SegmentedControl.tsx:120
 msgid "Double tap to select this segment"
 msgstr "Tuplaklikkaa valitaksesi tämä segmentti"
 
@@ -230,26 +230,30 @@ msgstr "Tuplaklikkaa valitaksesi tämä segmentti"
 msgid "Double tap to select this suggestion"
 msgstr "Tuplaklikkaa valitaksesi tämä ehdotus"
 
-#: src/app/(auth)/signup.tsx:236
+#: src/components/common/custom-bottom-bar/Tab.tsx:64
+msgid "Double tap to select this tab"
+msgstr ""
+
+#: src/app/(auth)/signup.tsx:238
 msgid "Double tap to signup with the provided information"
 msgstr "Tuplaklikkaa rekisteröityäksesi annetuilla tiedoilla"
 
-#: src/components/uikit/inputs/Checkbox.tsx:48
+#: src/components/uikit/inputs/Checkbox.tsx:54
 msgid "Double tap to uncheck this option"
 msgstr "Tuplaklikkaa poistaaksesi valinnan tästä vaihtoehdosta"
 
-#: src/app/(auth)/login.tsx:72
-#: src/app/(auth)/signup.tsx:86
+#: src/app/(auth)/login.tsx:74
+#: src/app/(auth)/signup.tsx:88
 msgid "Email"
 msgstr "Sähköposti"
 
-#: src/app/(auth)/login.tsx:64
-#: src/app/(auth)/signup.tsx:78
+#: src/app/(auth)/login.tsx:66
+#: src/app/(auth)/signup.tsx:80
 msgid "Email invalid"
 msgstr "Virheellinen sähköposti"
 
-#: src/app/(auth)/login.tsx:66
-#: src/app/(auth)/signup.tsx:80
+#: src/app/(auth)/login.tsx:68
+#: src/app/(auth)/signup.tsx:82
 msgid "Email required"
 msgstr "Sähköposti on pakollinen"
 
@@ -264,19 +268,19 @@ msgstr "Englanti"
 msgid "Enjoying the app?"
 msgstr "Nautitko sovelluksesta?"
 
-#: src/components/uikit/inputs/TextInput.tsx:166
+#: src/components/uikit/inputs/TextInput.tsx:168
 msgid "Enter your {label} here"
 msgstr "Anna {label} tähän"
 
-#: src/app/(auth)/login.tsx:40
+#: src/app/(auth)/login.tsx:42
 msgid "Enter your credentials"
 msgstr "Syötä tunnuksesi"
 
-#: src/app/(auth)/login.tsx:30
+#: src/app/(auth)/login.tsx:32
 msgid "Failed to login"
 msgstr "Sisäänkirjautuminen epäonnistui"
 
-#: src/app/(auth)/signup.tsx:46
+#: src/app/(auth)/signup.tsx:48
 msgid "Failed to signup"
 msgstr "Rekisteröityminen epäonnistui"
 
@@ -288,7 +292,7 @@ msgstr "Palaute on pakollinen"
 msgid "Feedback sent!"
 msgstr "Palaute lähetetty!"
 
-#: src/components/settings/SystemInfoMenuTarget.tsx:30
+#: src/components/settings/SystemInfoMenuTarget.tsx:31
 msgid "Fetching..."
 msgstr "Haetaan..."
 
@@ -298,20 +302,21 @@ msgstr "Haetaan..."
 msgid "Finnish"
 msgstr "Suomi"
 
-#: src/app/(auth)/signup.tsx:108
+#: src/app/(auth)/signup.tsx:110
 msgid "First name"
 msgstr "Etunimi"
 
-#: src/app/(auth)/signup.tsx:103
+#: src/app/(auth)/signup.tsx:105
 msgid "First name is required"
 msgstr "Etunimi on pakollinen"
 
-#: src/components/uikit/inputs/TextInput.tsx:179
+#: src/components/uikit/inputs/TextInput.tsx:181
 msgid "Hide text by toggling visibility"
 msgstr "Piilota teksti vaihtamalla näkyvyyttä"
 
-#: src/app/(tabs)/_layout.tsx:27
-#: src/app/(tabs)/home.tsx:20
+#: src/app/(tabs)/_layout.tsx:52
+#: src/app/(tabs)/_layout.web.tsx:20
+#: src/app/(tabs)/home.tsx:10
 msgid "Home"
 msgstr "Koti"
 
@@ -319,11 +324,11 @@ msgstr "Koti"
 msgid "How can we improve?"
 msgstr "Kuinka voimme parantaa?"
 
-#: src/app/(tabs)/settings.tsx:28
+#: src/app/(tabs)/settings.tsx:31
 msgid "I am sure"
 msgstr "Olen varma"
 
-#: src/components/uikit/buttons/IconButton.tsx:87
+#: src/components/uikit/buttons/IconButton.tsx:95
 msgid "Icon button with {icon} icon"
 msgstr "Kuvakepainike, jossa {icon} kuvake"
 
@@ -331,15 +336,15 @@ msgstr "Kuvakepainike, jossa {icon} kuvake"
 msgid "Info"
 msgstr "Tiedot"
 
-#: src/components/uikit/inputs/TextInput.tsx:210
+#: src/components/uikit/inputs/TextInput.tsx:212
 msgid "Informational message for the {label} input field"
 msgstr "Informatiivinen viesti {label} syötekentälle"
 
-#: src/components/common/MenuList.tsx:66
+#: src/components/common/MenuList.tsx:68
 msgid "Item"
 msgstr "Kohde"
 
-#: src/components/uikit/inputs/TextInput.tsx:105
+#: src/components/uikit/inputs/TextInput.tsx:107
 msgid "Label for {label} input"
 msgstr "Nimike {label} syötteelle"
 
@@ -355,11 +360,11 @@ msgstr ""
 msgid "Language set to Finnish"
 msgstr ""
 
-#: src/app/(auth)/signup.tsx:127
+#: src/app/(auth)/signup.tsx:129
 msgid "Last name"
 msgstr "Sukunimi"
 
-#: src/app/(auth)/signup.tsx:122
+#: src/app/(auth)/signup.tsx:124
 msgid "Last name is required"
 msgstr "Sukunimi on pakollinen"
 
@@ -368,20 +373,20 @@ msgstr "Sukunimi on pakollinen"
 msgid "Light"
 msgstr "Vaalea"
 
-#: src/app/(auth)/login.tsx:26
+#: src/app/(auth)/login.tsx:27
 msgid "Logged in successfully, entering the app"
 msgstr "Kirjautuminen onnistui, siirrytään sovellukseen"
 
-#: src/app/(tabs)/settings.tsx:21
+#: src/app/(tabs)/settings.tsx:23
 msgid "Logged out successfully, back to the landing page"
 msgstr "Uloskirjautuminen onnistui, palataan aloitussivulle"
 
 #: src/app/(auth)/_layout.tsx:14
-#: src/app/(auth)/login.tsx:119
+#: src/app/(auth)/login.tsx:121
 msgid "Login"
 msgstr "Kirjaudu sisään"
 
-#: src/app/(tabs)/settings.tsx:39
+#: src/app/(tabs)/settings.tsx:42
 msgid "Logout"
 msgstr "Kirjaudu ulos"
 
@@ -389,7 +394,7 @@ msgstr "Kirjaudu ulos"
 msgid "Loving it"
 msgstr "Rakastan tätä"
 
-#: src/components/settings/SystemInfoMenuTarget.tsx:35
+#: src/components/settings/SystemInfoMenuTarget.tsx:36
 msgid "Model name"
 msgstr "Mallin nimi"
 
@@ -405,7 +410,7 @@ msgstr "Siirtyy rekisteröitymisnäyttöön"
 msgid "No results found."
 msgstr "Ei tuloksia."
 
-#: src/components/uikit/inputs/TextInput.tsx:129
+#: src/components/uikit/inputs/TextInput.tsx:131
 msgid "Number of characters entered in the input field: currently {characterCount} out of {maxLength}"
 msgstr "Syötekenttään syötettyjen merkkien määrä: tällä hetkellä {characterCount} / {maxLength}"
 
@@ -423,27 +428,27 @@ msgstr "Avaa asetukset"
 msgid "Or"
 msgstr "Tai"
 
-#: src/app/(auth)/login.tsx:95
-#: src/app/(auth)/signup.tsx:178
+#: src/app/(auth)/login.tsx:97
+#: src/app/(auth)/signup.tsx:180
 msgid "Password"
 msgstr "Salasana"
 
-#: src/app/(auth)/signup.tsx:214
+#: src/app/(auth)/signup.tsx:216
 msgid "Password again"
 msgstr "Salasana uudelleen"
 
-#: src/app/(auth)/login.tsx:90
-#: src/app/(auth)/signup.tsx:172
-#: src/app/(auth)/signup.tsx:208
+#: src/app/(auth)/login.tsx:92
+#: src/app/(auth)/signup.tsx:174
+#: src/app/(auth)/signup.tsx:210
 msgid "Password is required"
 msgstr "Salasana on pakollinen"
 
-#: src/app/(auth)/signup.tsx:170
-#: src/app/(auth)/signup.tsx:206
+#: src/app/(auth)/signup.tsx:172
+#: src/app/(auth)/signup.tsx:208
 msgid "Password must be at least 8 characters"
 msgstr "Salasanan on oltava vähintään 8 merkkiä pitkä"
 
-#: src/app/(auth)/signup.tsx:204
+#: src/app/(auth)/signup.tsx:206
 msgid "Passwords do not match"
 msgstr "Salasanat eivät täsmää"
 
@@ -451,11 +456,11 @@ msgstr "Salasanat eivät täsmää"
 msgid "phone app"
 msgstr "puhelinsovellus"
 
-#: src/app/(auth)/signup.tsx:150
+#: src/app/(auth)/signup.tsx:152
 msgid "Phone number"
 msgstr "Puhelinnumero"
 
-#: src/app/(auth)/signup.tsx:141
+#: src/app/(auth)/signup.tsx:143
 msgid "Phone number is required"
 msgstr "Puhelinnumero on pakollinen"
 
@@ -467,24 +472,26 @@ msgstr "Valintaikkuna"
 msgid "Please try restarting the application."
 msgstr "Yritä käynnistää sovellus uudelleen."
 
-#: src/app/(auth)/signup.tsx:145
+#: src/app/(auth)/signup.tsx:147
 msgid "Preferred format: +358400123456"
 msgstr "Suositeltu muoto: +358400123456"
 
-#: src/app/(tabs)/_layout.tsx:40
+#: src/app/(tabs)/_layout.tsx:65
+#: src/app/(tabs)/_layout.web.tsx:33
 #: src/app/(tabs)/profile.tsx:10
 msgid "Profile"
 msgstr "Profiili"
 
-#: src/components/uikit/inputs/Radio.tsx:26
+#: src/components/uikit/inputs/Radio.tsx:33
 msgid "Radio option: {label}"
 msgstr "Valintanapin vaihtoehto: {label}"
 
-#: src/components/uikit/inputs/TextInput.tsx:114
+#: src/components/uikit/inputs/TextInput.tsx:116
 msgid "Required field indicator"
 msgstr "Pakollisen kentän merkki"
 
-#: src/app/(tabs)/_layout.tsx:33
+#: src/app/(tabs)/_layout.tsx:58
+#: src/app/(tabs)/_layout.web.tsx:26
 #: src/app/(tabs)/search.tsx:10
 #: src/components/uikit/inputs/SearchInput.tsx:28
 msgid "Search"
@@ -498,27 +505,28 @@ msgstr ""
 msgid "Search options"
 msgstr ""
 
-#: src/components/uikit/SegmentedControl.tsx:117
+#: src/components/uikit/SegmentedControl.tsx:119
 msgid "Segment {label}"
 msgstr ""
 
-#: src/components/uikit/inputs/Select.tsx:62
+#: src/components/uikit/inputs/Select.tsx:63
 msgid "Select"
 msgstr "Valitse"
 
-#: src/components/uikit/inputs/Select.tsx:122
+#: src/components/uikit/inputs/Select.tsx:124
 msgid "Select input for {label}, current value: {value}"
 msgstr ""
 
-#: src/components/common/MenuList.tsx:66
+#: src/components/common/MenuList.tsx:68
 msgid "Selected value"
 msgstr ""
 
-#: src/app/(tabs)/_layout.tsx:47
+#: src/app/(tabs)/_layout.tsx:72
+#: src/app/(tabs)/_layout.web.tsx:40
 msgid "Settings"
 msgstr "Asetukset"
 
-#: src/components/uikit/inputs/TextInput.tsx:180
+#: src/components/uikit/inputs/TextInput.tsx:182
 msgid "Show text by toggling visibility"
 msgstr "Näytä teksti vaihtamalla näkyvyyttä"
 
@@ -527,12 +535,12 @@ msgstr "Näytä teksti vaihtamalla näkyvyyttä"
 msgid "Sign in"
 msgstr "Kirjaudu sisään"
 
-#: src/app/(auth)/signup.tsx:42
+#: src/app/(auth)/signup.tsx:43
 msgid "Signed up successfully, entering the app"
 msgstr "Rekisteröityminen onnistui, siirrytään sovellukseen"
 
 #: src/app/(auth)/_layout.tsx:15
-#: src/app/(auth)/signup.tsx:238
+#: src/app/(auth)/signup.tsx:240
 msgid "Signup"
 msgstr "Rekisteröidy"
 
@@ -559,7 +567,7 @@ msgstr "Lähetä palaute"
 msgid "Suomi"
 msgstr "Suomi"
 
-#: src/components/settings/SystemInfoMenuTarget.tsx:40
+#: src/components/settings/SystemInfoMenuTarget.tsx:41
 msgid "System version"
 msgstr "Järjestelmän versio"
 
@@ -572,15 +580,15 @@ msgstr "Taito-pohja"
 msgid "Thank you"
 msgstr "Kiitos"
 
-#: src/components/uikit/inputs/TextInput.tsx:115
+#: src/components/uikit/inputs/TextInput.tsx:117
 msgid "This field is marked as required"
 msgstr ""
 
-#: src/components/uikit/inputs/TextInput.tsx:211
+#: src/components/uikit/inputs/TextInput.tsx:213
 msgid "This is an error message for the {label} input field"
 msgstr "Tämä on virheilmoitus {label} syötekentälle"
 
-#: src/components/uikit/inputs/TextInput.tsx:176
+#: src/components/uikit/inputs/TextInput.tsx:178
 msgid "Toggle visibility"
 msgstr "Vaihda näkyvyyttä"
 
@@ -588,7 +596,7 @@ msgstr "Vaihda näkyvyyttä"
 msgid "Try changing your search term."
 msgstr "Kokeile muuttaa hakutermiä."
 
-#: src/components/uikit/inputs/TextInput.tsx:39
+#: src/components/uikit/inputs/TextInput.tsx:40
 msgid "Type here"
 msgstr "Kirjoita tähän"
 
@@ -604,15 +612,15 @@ msgstr ""
 msgid "Unable to change permission"
 msgstr "Lupaa ei voitu muuttaa"
 
-#: src/components/settings/SystemInfoMenuTarget.tsx:31
+#: src/components/settings/SystemInfoMenuTarget.tsx:32
 msgid "Unavailable"
 msgstr "Ei saatavilla"
 
-#: src/components/settings/SystemInfoMenuTarget.tsx:66
+#: src/components/settings/SystemInfoMenuTarget.tsx:67
 msgid "Update ID"
 msgstr "Päivitystunnus"
 
-#: src/components/settings/SystemInfoMenuTarget.tsx:51
+#: src/components/settings/SystemInfoMenuTarget.tsx:52
 msgid "Version"
 msgstr "Versio"
 
@@ -621,7 +629,7 @@ msgstr "Versio"
 msgid "Welcome to"
 msgstr "Tervetuloa"
 
-#: src/app/(auth)/login.tsx:47
+#: src/app/(auth)/login.tsx:49
 msgid "You can enter any email and password to login."
 msgstr "Voit syöttää minkä tahansa sähköpostin ja salasanan kirjautuaksesi"
 


### PR DESCRIPTION
## ✨ What has changed?

This PR adds sentry to the project and documentation on how to set it up for a new project made from the template.

1. Config files `app.config.ts` and `metro.config.ts` are changed.
2. npm package installed
3. Code changes in `src/app/_layout.tsx` which initialize sentry and implement navigation tracking so that we see in Sentry how the user has navigated before the error
4. README.md changes which describe necessary steps to set up the project in sentry.io and to enable uploading of source maps in expo project
5. Tracing is set to zero, as I don't think by default we are interested in tracing performance. Projects can adjust that as necessary.



## 🔍 How to verify?

1. Add the sentry DSN env variable (instructions in docs)
2. Throw an error in the code in any way
3. Go to https://sentry.io project: `react-native` and see the error there (or look at the errors I previously sent there)

## 🧪 Added tests?

- [ ] 👍 Yes
- [x] 🙅 No, why not? Because this is sentry.

<!-- If no tests are added, tell us why. -->
